### PR TITLE
feat: add report export in CSV and Markdown formats

### DIFF
--- a/internal/dashboard/export.go
+++ b/internal/dashboard/export.go
@@ -1,0 +1,179 @@
+package dashboard
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/nebari-dev/provenance-collector/internal/report"
+)
+
+func (s *Server) handleExport(w http.ResponseWriter, r *http.Request) {
+	format := r.URL.Query().Get("format")
+	if format == "" {
+		format = "csv"
+	}
+
+	rpt, err := s.loadReport("provenance-latest.json")
+	if err != nil {
+		http.Error(w, "no report available", http.StatusNotFound)
+		return
+	}
+
+	switch format {
+	case "csv":
+		s.exportCSV(w, rpt)
+	case "markdown", "md":
+		s.exportMarkdown(w, rpt)
+	default:
+		http.Error(w, "unsupported format: use csv or markdown", http.StatusBadRequest)
+	}
+}
+
+func (s *Server) exportCSV(w http.ResponseWriter, rpt *report.ProvenanceReport) {
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("Content-Disposition", "attachment; filename=provenance-report.csv")
+
+	var b strings.Builder
+	b.WriteString("Image,Namespace,Workload Kind,Workload Name,Digest,Signed,Verified,SLSA Provenance,SBOM,SBOM Format,Update Available,Current Tag,Latest In Major\n")
+
+	for _, img := range rpt.Images {
+		signed, verified := "false", "false"
+		if img.Signature != nil {
+			signed = fmt.Sprintf("%t", img.Signature.Signed)
+			verified = fmt.Sprintf("%t", img.Signature.Verified)
+		}
+
+		slsa := "false"
+		if img.Provenance != nil {
+			slsa = fmt.Sprintf("%t", img.Provenance.HasProvenance)
+		}
+
+		sbom, sbomFmt := "false", ""
+		if img.SBOM != nil {
+			sbom = fmt.Sprintf("%t", img.SBOM.HasSBOM)
+			sbomFmt = img.SBOM.Format
+		}
+
+		updateAvail, currentTag, latestInMajor := "false", "", ""
+		if img.Update != nil {
+			updateAvail = fmt.Sprintf("%t", img.Update.UpdateAvailable)
+			currentTag = img.Update.CurrentTag
+			latestInMajor = img.Update.LatestInMajor
+		}
+
+		b.WriteString(fmt.Sprintf("%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n",
+			csvEscape(img.Image),
+			csvEscape(img.Namespace),
+			csvEscape(img.Workload.Kind),
+			csvEscape(img.Workload.Name),
+			csvEscape(img.Digest),
+			signed, verified, slsa, sbom,
+			csvEscape(sbomFmt),
+			updateAvail,
+			csvEscape(currentTag),
+			csvEscape(latestInMajor),
+		))
+	}
+
+	_, _ = w.Write([]byte(b.String()))
+}
+
+func (s *Server) exportMarkdown(w http.ResponseWriter, rpt *report.ProvenanceReport) {
+	w.Header().Set("Content-Type", "text/markdown")
+	w.Header().Set("Content-Disposition", "attachment; filename=provenance-report.md")
+
+	var b strings.Builder
+
+	b.WriteString("# Provenance Report\n\n")
+	b.WriteString(fmt.Sprintf("**Generated:** %s\n\n", rpt.Metadata.GeneratedAt.Format("2006-01-02 15:04:05 UTC")))
+	if rpt.Metadata.ClusterName != "" {
+		b.WriteString(fmt.Sprintf("**Cluster:** %s\n\n", rpt.Metadata.ClusterName))
+	}
+	b.WriteString(fmt.Sprintf("**Namespaces:** %s\n\n", strings.Join(rpt.Metadata.NamespacesScanned, ", ")))
+
+	// Summary
+	s2 := rpt.Summary
+	b.WriteString("## Summary\n\n")
+	b.WriteString("| Metric | Count |\n|---|---|\n")
+	b.WriteString(fmt.Sprintf("| Unique Images | %d |\n", s2.UniqueImages))
+	b.WriteString(fmt.Sprintf("| Signed | %d |\n", s2.SignedImages))
+	b.WriteString(fmt.Sprintf("| Verified | %d |\n", s2.VerifiedImages))
+	b.WriteString(fmt.Sprintf("| SLSA Provenance | %d |\n", s2.ImagesWithProvenance))
+	b.WriteString(fmt.Sprintf("| With SBOM | %d |\n", s2.ImagesWithSBOM))
+	b.WriteString(fmt.Sprintf("| Updates Available | %d |\n", s2.ImagesWithUpdates))
+	b.WriteString(fmt.Sprintf("| Helm Releases | %d |\n", s2.TotalHelmReleases))
+	b.WriteString("\n")
+
+	// Images table
+	b.WriteString("## Container Images\n\n")
+	b.WriteString("| Image | Namespace | Workload | Signed | SLSA | SBOM | Update |\n")
+	b.WriteString("|---|---|---|---|---|---|---|\n")
+
+	for _, img := range rpt.Images {
+		signed := "-"
+		if img.Signature != nil {
+			if img.Signature.Verified {
+				signed = "Verified"
+			} else if img.Signature.Signed {
+				signed = "Signed"
+			} else {
+				signed = "No"
+			}
+		}
+
+		slsa := "-"
+		if img.Provenance != nil {
+			if img.Provenance.HasProvenance {
+				slsa = "Yes"
+			} else {
+				slsa = "No"
+			}
+		}
+
+		sbom := "-"
+		if img.SBOM != nil {
+			if img.SBOM.HasSBOM {
+				sbom = strings.ToUpper(img.SBOM.Format)
+			} else {
+				sbom = "No"
+			}
+		}
+
+		update := "-"
+		if img.Update != nil {
+			if img.Update.UpdateAvailable {
+				update = img.Update.LatestInMajor
+				if update == "" {
+					update = img.Update.NewestAvailable
+				}
+			} else {
+				update = "Current"
+			}
+		}
+
+		workload := fmt.Sprintf("%s/%s", img.Workload.Kind, img.Workload.Name)
+		b.WriteString(fmt.Sprintf("| `%s` | %s | %s | %s | %s | %s | %s |\n",
+			img.Image, img.Namespace, workload, signed, slsa, sbom, update))
+	}
+
+	// Helm releases
+	if len(rpt.HelmReleases) > 0 {
+		b.WriteString("\n## Helm Releases\n\n")
+		b.WriteString("| Release | Namespace | Chart | Version | App Version | Status |\n")
+		b.WriteString("|---|---|---|---|---|---|\n")
+		for _, hr := range rpt.HelmReleases {
+			b.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %s |\n",
+				hr.ReleaseName, hr.Namespace, hr.Chart, hr.Version, hr.AppVersion, hr.Status))
+		}
+	}
+
+	_, _ = w.Write([]byte(b.String()))
+}
+
+func csvEscape(s string) string {
+	if strings.ContainsAny(s, ",\"\n") {
+		return "\"" + strings.ReplaceAll(s, "\"", "\"\"") + "\""
+	}
+	return s
+}

--- a/internal/dashboard/export.go
+++ b/internal/dashboard/export.go
@@ -62,7 +62,7 @@ func (s *Server) exportCSV(w http.ResponseWriter, rpt *report.ProvenanceReport) 
 			latestInMajor = img.Update.LatestInMajor
 		}
 
-		b.WriteString(fmt.Sprintf("%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n",
+		fmt.Fprintf(&b, "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n",
 			csvEscape(img.Image),
 			csvEscape(img.Namespace),
 			csvEscape(img.Workload.Kind),
@@ -73,7 +73,7 @@ func (s *Server) exportCSV(w http.ResponseWriter, rpt *report.ProvenanceReport) 
 			updateAvail,
 			csvEscape(currentTag),
 			csvEscape(latestInMajor),
-		))
+		)
 	}
 
 	_, _ = w.Write([]byte(b.String()))
@@ -86,9 +86,9 @@ func (s *Server) exportMarkdown(w http.ResponseWriter, rpt *report.ProvenanceRep
 	var b strings.Builder
 
 	b.WriteString("# Provenance Report\n\n")
-	b.WriteString(fmt.Sprintf("**Generated:** %s\n\n", rpt.Metadata.GeneratedAt.Format("2006-01-02 15:04:05 UTC")))
+	fmt.Fprintf(&b, "**Generated:** %s\n\n", rpt.Metadata.GeneratedAt.Format("2006-01-02 15:04:05 UTC"))
 	if rpt.Metadata.ClusterName != "" {
-		b.WriteString(fmt.Sprintf("**Cluster:** %s\n\n", rpt.Metadata.ClusterName))
+		fmt.Fprintf(&b, "**Cluster:** %s\n\n", rpt.Metadata.ClusterName)
 	}
 	b.WriteString(fmt.Sprintf("**Namespaces:** %s\n\n", strings.Join(rpt.Metadata.NamespacesScanned, ", ")))
 

--- a/internal/dashboard/export_test.go
+++ b/internal/dashboard/export_test.go
@@ -1,0 +1,154 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestExportCSV(t *testing.T) {
+	dir := setupTestDir(t)
+	srv := NewServer(dir)
+
+	req := httptest.NewRequest("GET", "/api/export?format=csv", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/csv" {
+		t.Errorf("expected text/csv, got %s", ct)
+	}
+	if cd := w.Header().Get("Content-Disposition"); !strings.Contains(cd, "provenance-report.csv") {
+		t.Errorf("expected csv filename in Content-Disposition, got %s", cd)
+	}
+
+	body := w.Body.String()
+	lines := strings.Split(strings.TrimSpace(body), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected at least header + 1 row, got %d lines", len(lines))
+	}
+	// Check header
+	if !strings.HasPrefix(lines[0], "Image,Namespace,") {
+		t.Errorf("unexpected CSV header: %s", lines[0])
+	}
+	// Check data row contains test image
+	if !strings.Contains(lines[1], "nginx:1.27") {
+		t.Errorf("expected nginx:1.27 in CSV data, got: %s", lines[1])
+	}
+}
+
+func TestExportMarkdown(t *testing.T) {
+	dir := setupTestDir(t)
+	srv := NewServer(dir)
+
+	req := httptest.NewRequest("GET", "/api/export?format=markdown", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/markdown" {
+		t.Errorf("expected text/markdown, got %s", ct)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "# Provenance Report") {
+		t.Error("expected markdown to contain report title")
+	}
+	if !strings.Contains(body, "## Summary") {
+		t.Error("expected markdown to contain summary section")
+	}
+	if !strings.Contains(body, "## Container Images") {
+		t.Error("expected markdown to contain images section")
+	}
+	if !strings.Contains(body, "nginx:1.27") {
+		t.Error("expected markdown to contain test image")
+	}
+	if !strings.Contains(body, "## Helm Releases") {
+		t.Error("expected markdown to contain helm section")
+	}
+	if !strings.Contains(body, "ingress-nginx") {
+		t.Error("expected markdown to contain test helm release")
+	}
+}
+
+func TestExportMdShorthand(t *testing.T) {
+	dir := setupTestDir(t)
+	srv := NewServer(dir)
+
+	req := httptest.NewRequest("GET", "/api/export?format=md", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/markdown" {
+		t.Errorf("expected text/markdown, got %s", ct)
+	}
+}
+
+func TestExportDefaultFormat(t *testing.T) {
+	dir := setupTestDir(t)
+	srv := NewServer(dir)
+
+	// No format param defaults to CSV
+	req := httptest.NewRequest("GET", "/api/export", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/csv" {
+		t.Errorf("expected default format csv, got %s", ct)
+	}
+}
+
+func TestExportUnsupportedFormat(t *testing.T) {
+	dir := setupTestDir(t)
+	srv := NewServer(dir)
+
+	req := httptest.NewRequest("GET", "/api/export?format=pdf", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for unsupported format, got %d", w.Code)
+	}
+}
+
+func TestExportNoReport(t *testing.T) {
+	srv := NewServer(t.TempDir())
+
+	req := httptest.NewRequest("GET", "/api/export?format=csv", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 when no report exists, got %d", w.Code)
+	}
+}
+
+func TestCSVEscape(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"simple", "simple"},
+		{"has,comma", "\"has,comma\""},
+		{"has\"quote", "\"has\"\"quote\""},
+		{"has\nnewline", "\"has\nnewline\""},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		got := csvEscape(tc.input)
+		if got != tc.want {
+			t.Errorf("csvEscape(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}

--- a/internal/dashboard/index.go
+++ b/internal/dashboard/index.go
@@ -108,6 +108,11 @@ const indexHTML = `<!DOCTYPE html>
   .timeline-item .time { font-size: 11px; color: var(--muted); }
   .timeline-item .count { font-size: 10px; color: var(--faint); margin-top: 2px; }
 
+  /* Export buttons */
+  .export-group { display: flex; gap: 4px; }
+  .export-btn { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 4px 10px; color: var(--muted); font-size: 11px; font-family: var(--font); cursor: pointer; transition: all 0.15s ease; text-decoration: none; display: inline-flex; align-items: center; gap: 4px; }
+  .export-btn:hover { border-color: var(--purple-dark); color: var(--text); }
+
   /* Pagination */
   .pagination { display: flex; align-items: center; justify-content: space-between; padding: 8px 20px; border-top: 1px solid var(--border); font-size: 11px; color: var(--muted); }
   .pagination .page-info { }
@@ -164,6 +169,11 @@ const indexHTML = `<!DOCTYPE html>
     <div class="nav-meta">
       <span id="cluster-name"></span>
       <span id="last-updated"></span>
+      <div class="export-group">
+        <a class="export-btn" href="/api/export?format=csv" download>CSV</a>
+        <a class="export-btn" href="/api/export?format=markdown" download>Markdown</a>
+        <a class="export-btn" href="/api/reports/latest" download="provenance-report.json">JSON</a>
+      </div>
     </div>
   </div>
 </nav>

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -25,6 +25,7 @@ func NewServer(reportsDir string) *Server {
 	mux.HandleFunc("/", s.handleIndex)
 	mux.HandleFunc("/api/reports", s.handleListReports)
 	mux.HandleFunc("/api/reports/", s.handleGetReport)
+	mux.HandleFunc("/api/export", s.handleExport)
 	mux.HandleFunc("/healthz", s.handleHealthz)
 	s.mux = mux
 	return s


### PR DESCRIPTION
## Summary

Closes #3

Add report export functionality to the web dashboard with CSV, Markdown, and JSON download buttons. Reports can be exported via the UI or the API endpoint.

## Changes

### `internal/dashboard/export.go`
- New `/api/export` endpoint with `?format=csv|markdown|md` parameter
- CSV export: flat table with all image provenance fields (signature, SLSA, SBOM, update status)
- Markdown export: formatted report with metadata, summary table, images table, and Helm releases table
- Proper Content-Disposition headers for browser download

### `internal/dashboard/server.go`
- Register `/api/export` route

### `internal/dashboard/index.go`
- Add CSV, Markdown, and JSON export buttons in the nav bar

### `internal/dashboard/export_test.go`
- Tests for CSV, Markdown, md shorthand, default format, unsupported format, missing report, and CSV escaping

## Before / After

```bash
# Before
# No way to export reports from the UI — had to read PVC or ConfigMap directly

# After
# Export buttons in the dashboard nav bar
# Or via API:
curl http://localhost:8080/api/export?format=csv > report.csv
curl http://localhost:8080/api/export?format=markdown > report.md
curl http://localhost:8080/api/reports/latest > report.json
```
