### PR TITLE
feat: add http upload mode so collector and dashboard stop sharing a PVC

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -50,16 +50,15 @@ jobs:
           kubectl create deployment redis --image=redis:7-alpine
           kubectl wait --for=condition=available deployment/nginx deployment/redis --timeout=120s
 
-      # Install the chart with web UI enabled and PVC for report storage
+      # Install the chart with the default http upload mode (kind ships a
+      # local-path storage class, so the dashboard PVC binds without extra config).
       - name: Install provenance-collector chart
         run: |
           helm install provenance-test chart/ \
             --set image.repository=provenance-collector \
             --set image.tag=test \
             --set image.pullPolicy=Never \
-            --set config.reportOutput=pvc \
-            --set config.reportConfigMap=provenance-report \
-            --set persistence.enabled=true \
+            --set persistence.mode=http \
             --set config.verifySignatures=false \
             --set config.checkUpdates=false \
             --set config.helmEnabled=true \

--- a/README.md
+++ b/README.md
@@ -64,9 +64,8 @@ kubectl port-forward -n provenance-system \
   svc/provenance-collector-web 8080:8080
 # Open http://localhost:8080
 
-# Or fetch the latest JSON directly:
-kubectl exec -n provenance-system deploy/provenance-collector-web -- \
-  wget -qO- http://localhost:8080/api/reports/latest | jq .
+# In another shell, fetch the latest JSON:
+curl -s http://localhost:8080/api/reports/latest | jq .
 
 # persistence.mode=configmap — no dashboard required.
 kubectl get configmap provenance-report \

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Deployed as a **Kubernetes CronJob** and packaged as a
 | **Helm Release Tracking** | Discovers all deployed Helm releases with chart versions |
 | **Web Dashboard** | Optional UI with filters, sorting, pagination, and image detail panel |
 | **Grafana Integration** | JSON API compatible with the Infinity datasource for dashboards and alerting |
-| **Provenance Reports** | Outputs timestamped JSON reports to PVC or ConfigMap with automatic retention |
+| **Provenance Reports** | Outputs timestamped JSON reports via the dashboard's internal upload endpoint (default), a shared PVC, or a ConfigMap, with automatic retention |
 
 ## Quick Start
 
@@ -59,14 +59,36 @@ kubectl create job --from=cronjob/provenance-collector \
 ### View the Report
 
 ```bash
-# PVC-based (default)
-kubectl logs -n provenance-system job/manual-run
+# Default (persistence.mode=http) — read from the dashboard.
+kubectl port-forward -n provenance-system \
+  svc/provenance-collector-web 8080:8080
+# Open http://localhost:8080
 
-# ConfigMap-based
+# Or fetch the latest JSON directly:
+kubectl exec -n provenance-system deploy/provenance-collector-web -- \
+  wget -qO- http://localhost:8080/api/reports/latest | jq .
+
+# persistence.mode=configmap — no dashboard required.
 kubectl get configmap provenance-report \
   -n provenance-system \
   -o jsonpath='{.data.report\.json}' | jq .
 ```
+
+## Storage modes
+
+`persistence.mode` controls how reports get from the collector Job to the
+dashboard. Pick one:
+
+| Mode | What it does | Use it when |
+|---|---|---|
+| `http` *(default)* | Collector POSTs the JSON to the dashboard's internal Service (`{fullname}-web-internal:8081/internal/reports`, cluster-DNS only). The dashboard pod owns a single PVC; nothing else mounts it. | You're on RWO-only storage (Hetzner `csi.hetzner.cloud`, most cloud CSIs). This is the safe default. |
+| `pvc` | Collector and dashboard share one PVC at `config.reportPath`. `persistence.storageClass` is required and must be ReadWriteMany-capable (Longhorn, NFS, EFS, …) unless every collector pod is guaranteed to land on the same node as the dashboard. The chart fails to render if `storageClass` is empty in this mode. | You already have an RWX-capable storage class and prefer filesystem semantics. |
+| `configmap` | Collector writes the report to a ConfigMap. The dashboard is not used. | Headless / inspection-only installs. |
+
+The internal upload endpoint is exposed through a dedicated Service
+(`{fullname}-web-internal`) that the NebariApp / public Ingress never
+references. Apply a NetworkPolicy restricting it to the collector
+ServiceAccount if your cluster supports it.
 
 ## Web Dashboard
 
@@ -153,9 +175,11 @@ All configuration is via environment variables, set through `values.yaml`:
 | `PROVENANCE_CHECK_UPDATES` | `true` | Check for newer image tags |
 | `PROVENANCE_UPDATE_LEVEL` | `patch` | Min version bump to flag: `patch`, `minor`, or `major` |
 | `PROVENANCE_SKIP_PRERELEASE` | `true` | Ignore alpha/beta/RC versions in updates |
-| `PROVENANCE_REPORT_OUTPUT` | `pvc` | Report output: `pvc` or `configmap` |
-| `PROVENANCE_REPORT_PATH` | `/reports` | Filesystem path for PVC reports |
+| `PROVENANCE_REPORT_OUTPUT` | `http` | Report output: `http`, `pvc`, or `configmap` |
+| `PROVENANCE_REPORT_PATH` | `/reports` | Filesystem path (dashboard pod in http mode; both pods in pvc mode) |
 | `PROVENANCE_REPORT_RETENTION` | `168h` | Auto-prune reports older than this (`-1` to disable) |
+| `PROVENANCE_REPORT_UPLOAD_URL` | *(set by chart)* | Dashboard upload URL used in http mode |
+| `PROVENANCE_REPORT_UPLOAD_TIMEOUT` | `30s` | Timeout for the upload request in http mode |
 | `PROVENANCE_REGISTRY_TIMEOUT` | `30s` | Timeout for registry operations |
 | `PROVENANCE_CLUSTER_NAME` | *(empty)* | Cluster name in report metadata |
 
@@ -230,15 +254,16 @@ config:
   checkUpdates: true
   updateLevel: "patch"        # "patch", "minor", or "major"
   skipPrerelease: true
-  reportOutput: "pvc"         # "pvc" or "configmap"
   reportRetention: "168h"     # 1 week, "-1" to keep forever
+  reportPath: /reports
 
 persistence:
-  enabled: true
+  mode: http                  # http | pvc | configmap (see "Storage modes" above)
+  storageClass: ""            # Required when mode=pvc
   size: 1Gi
 
 webUI:
-  enabled: false              # Enable the web dashboard
+  enabled: true               # Required in http mode (hosts the upload endpoint)
 
 # Nebari integration (optional)
 nebariapp:
@@ -286,8 +311,8 @@ helm install pc chart/ \
   --set image.repository=provenance-collector \
   --set image.tag=dev \
   --set image.pullPolicy=Never \
-  --set config.reportOutput=configmap \
-  --set persistence.enabled=false \
+  --set persistence.mode=configmap \
+  --set webUI.enabled=false \
   --set config.verifySignatures=false
 
 kubectl create job --from=cronjob/pc-provenance-collector test-run
@@ -317,7 +342,7 @@ internal/
   report/
     types.go                  Report JSON schema types
     generator.go              Orchestrator with concurrent enrichment
-    writer.go                 PVC and ConfigMap output writers
+    writer.go                 HTTP, PVC, and ConfigMap output writers
 chart/                        Helm chart (CronJob + RBAC + Dashboard + NebariApp)
 examples/                     Deployment examples (standalone, Nebari, ArgoCD)
 ```

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,6 +1,7 @@
 Provenance Collector has been deployed!
 
-Schedule: {{ .Values.schedule }}
+Storage mode: {{ .Values.persistence.mode }}
+Schedule:     {{ .Values.schedule }}
 
 To trigger a collection immediately:
 
@@ -8,16 +9,29 @@ To trigger a collection immediately:
     manual-run -n {{ .Release.Namespace }}
 
 To view the latest report:
-{{- if .Values.persistence.enabled }}
+{{- if eq .Values.persistence.mode "http" }}
 
-  # Get the most recent job pod
+  # Port-forward the dashboard, then open http://localhost:{{ .Values.webUI.port }}
+  kubectl port-forward -n {{ .Release.Namespace }} \
+    svc/{{ include "provenance-collector.fullname" . }}-web {{ .Values.webUI.port }}:{{ .Values.webUI.port }}
+
+  # Or hit the read API directly:
+  kubectl exec -n {{ .Release.Namespace }} deploy/{{ include "provenance-collector.fullname" . }}-web -- \
+    wget -qO- http://localhost:{{ .Values.webUI.port }}/api/reports/latest | jq .
+
+  Collector uploads land at:
+    POST http://{{ include "provenance-collector.fullname" . }}-web-internal.{{ .Release.Namespace }}.svc:{{ .Values.webUI.internalPort }}/internal/reports
+  Keep that Service unexposed. Add a NetworkPolicy to restrict it to the
+  collector ServiceAccount if your cluster supports it.
+{{- else if eq .Values.persistence.mode "pvc" }}
+
+  # storageClass: {{ .Values.persistence.storageClass }} (must be ReadWriteMany-capable
+  # unless collector and dashboard pods always co-schedule).
   POD=$(kubectl get pods -n {{ .Release.Namespace }} \
     -l app.kubernetes.io/name={{ include "provenance-collector.name" . }} \
     --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1].metadata.name}')
-
-  # Read the latest report from the PVC
   kubectl exec -n {{ .Release.Namespace }} $POD -- cat {{ .Values.config.reportPath }}/provenance-latest.json | jq .
-{{- else }}
+{{- else if eq .Values.persistence.mode "configmap" }}
 
   kubectl get configmap {{ .Values.config.reportConfigMap }} \
     -n {{ .Release.Namespace }} -o jsonpath='{.data.report\.json}' | jq .

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -15,9 +15,8 @@ To view the latest report:
   kubectl port-forward -n {{ .Release.Namespace }} \
     svc/{{ include "provenance-collector.fullname" . }}-web {{ .Values.webUI.port }}:{{ .Values.webUI.port }}
 
-  # Or hit the read API directly:
-  kubectl exec -n {{ .Release.Namespace }} deploy/{{ include "provenance-collector.fullname" . }}-web -- \
-    wget -qO- http://localhost:{{ .Values.webUI.port }}/api/reports/latest | jq .
+  # In another shell, hit the read API:
+  curl -s http://localhost:{{ .Values.webUI.port }}/api/reports/latest | jq .
 
   Collector uploads land at:
     POST http://{{ include "provenance-collector.fullname" . }}-web-internal.{{ .Release.Namespace }}.svc:{{ .Values.webUI.internalPort }}/internal/reports

--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -21,7 +21,7 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]
-  # Report output as ConfigMap (when reportOutput=configmap)
+  # Report output as ConfigMap (when persistence.mode=configmap)
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "create", "update"]

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -16,10 +16,14 @@ data:
   PROVENANCE_UPDATE_LEVEL: {{ .Values.config.updateLevel | quote }}
   PROVENANCE_CHECK_SBOM: {{ .Values.config.checkSBOM | quote }}
   PROVENANCE_CHECK_PROVENANCE: {{ .Values.config.checkProvenance | quote }}
-  PROVENANCE_REPORT_OUTPUT: {{ .Values.config.reportOutput | quote }}
+  PROVENANCE_REPORT_OUTPUT: {{ .Values.persistence.mode | quote }}
   PROVENANCE_REPORT_PATH: {{ .Values.config.reportPath | quote }}
   PROVENANCE_REPORT_RETENTION: {{ .Values.config.reportRetention | quote }}
   PROVENANCE_REPORT_CONFIGMAP: {{ .Values.config.reportConfigMap | quote }}
   PROVENANCE_REPORT_CONFIGMAP_NAMESPACE: {{ .Release.Namespace | quote }}
   PROVENANCE_REGISTRY_TIMEOUT: {{ .Values.config.registryTimeout | quote }}
   PROVENANCE_CLUSTER_NAME: {{ .Values.config.clusterName | quote }}
+  {{- if eq .Values.persistence.mode "http" }}
+  PROVENANCE_REPORT_UPLOAD_URL: {{ printf "http://%s-web-internal.%s.svc:%d/internal/reports" (include "provenance-collector.fullname" .) .Release.Namespace (int .Values.webUI.internalPort) | quote }}
+  PROVENANCE_REPORT_UPLOAD_TIMEOUT: {{ .Values.config.reportUploadTimeout | quote }}
+  {{- end }}

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -44,29 +44,28 @@ spec:
               envFrom:
                 - configMapRef:
                     name: {{ include "provenance-collector.fullname" . }}-config
-              {{- if .Values.persistence.enabled }}
-              volumeMounts:
-                - name: reports
-                  mountPath: {{ .Values.config.reportPath }}
-              {{- end }}
               {{- if .Values.registryCredentials.existingSecret }}
               env:
                 - name: PROVENANCE_REGISTRY_AUTH
                   value: /etc/docker/config.json
+              {{- end }}
+              {{- if or (eq .Values.persistence.mode "pvc") .Values.registryCredentials.existingSecret }}
               volumeMounts:
-                {{- if .Values.persistence.enabled }}
+                {{- if eq .Values.persistence.mode "pvc" }}
                 - name: reports
                   mountPath: {{ .Values.config.reportPath }}
                 {{- end }}
+                {{- if .Values.registryCredentials.existingSecret }}
                 - name: registry-creds
                   mountPath: /etc/docker
                   readOnly: true
+                {{- end }}
               {{- end }}
               resources:
                 {{- toYaml .Values.resources | nindent 16 }}
-          {{- if or .Values.persistence.enabled .Values.registryCredentials.existingSecret }}
+          {{- if or (eq .Values.persistence.mode "pvc") .Values.registryCredentials.existingSecret }}
           volumes:
-            {{- if .Values.persistence.enabled }}
+            {{- if eq .Values.persistence.mode "pvc" }}
             - name: reports
               persistentVolumeClaim:
                 claimName: {{ include "provenance-collector.fullname" . }}-reports

--- a/chart/templates/deployment-web.yaml
+++ b/chart/templates/deployment-web.yaml
@@ -9,6 +9,12 @@ metadata:
     app.kubernetes.io/component: web
 spec:
   replicas: {{ .Values.webUI.replicas }}
+  {{- if has .Values.persistence.mode (list "http" "pvc") }}
+  # Recreate avoids a multi-attach error on rollout: the old pod must
+  # detach the reports PVC before the new pod attaches it.
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       {{- include "provenance-collector.selectorLabels" . | nindent 6 }}
@@ -43,6 +49,12 @@ spec:
               value: {{ .Values.config.reportPath | quote }}
             - name: PROVENANCE_DASHBOARD_ADDR
               value: ":{{ .Values.webUI.port }}"
+            - name: PROVENANCE_DASHBOARD_INTERNAL_ADDR
+              value: ":{{ .Values.webUI.internalPort }}"
+            - name: PROVENANCE_REPORT_RETENTION
+              value: {{ .Values.config.reportRetention | quote }}
+            - name: PROVENANCE_UPLOAD_MAX_BYTES
+              value: {{ int .Values.webUI.uploadMaxBytes | quote }}
             - name: PROVENANCE_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -67,6 +79,11 @@ spec:
             - name: http
               containerPort: {{ .Values.webUI.port }}
               protocol: TCP
+            {{- if eq .Values.persistence.mode "http" }}
+            - name: internal
+              containerPort: {{ .Values.webUI.internalPort }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -79,14 +96,20 @@ spec:
               port: http
             initialDelaySeconds: 2
             periodSeconds: 10
+          {{- if has .Values.persistence.mode (list "http" "pvc") }}
           volumeMounts:
             - name: reports
               mountPath: {{ .Values.config.reportPath }}
+              {{- if eq .Values.persistence.mode "pvc" }}
               readOnly: true
+              {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.webUI.resources | nindent 12 }}
+      {{- if has .Values.persistence.mode (list "http" "pvc") }}
       volumes:
         - name: reports
           persistentVolumeClaim:
             claimName: {{ include "provenance-collector.fullname" . }}-reports
+      {{- end }}
 {{- end }}

--- a/chart/templates/pvc.yaml
+++ b/chart/templates/pvc.yaml
@@ -1,4 +1,14 @@
-{{- if .Values.persistence.enabled }}
+{{- if eq .Values.persistence.mode "http" }}
+{{- if not .Values.webUI.enabled }}
+{{- fail "persistence.mode=http requires webUI.enabled=true — the dashboard pod hosts the reports volume and the collector's upload endpoint." }}
+{{- end }}
+{{- end }}
+{{- if eq .Values.persistence.mode "pvc" }}
+{{- if not .Values.persistence.storageClass }}
+{{- fail "persistence.mode=pvc requires persistence.storageClass — pick a ReadWriteMany-capable class (Longhorn / NFS / EFS) unless your collector and dashboard pods are guaranteed to co-schedule on the same node. Hetzner's default csi.hetzner.cloud is ReadWriteOnce only and will cause Multi-Attach errors." }}
+{{- end }}
+{{- end }}
+{{- if has .Values.persistence.mode (list "http" "pvc") }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -11,7 +21,11 @@ spec:
   storageClassName: {{ . }}
   {{- end }}
   accessModes:
+    {{- if eq .Values.persistence.mode "pvc" }}
     {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+    {{- else }}
+    - ReadWriteOnce
+    {{- end }}
   resources:
     requests:
       storage: {{ .Values.persistence.size }}

--- a/chart/templates/service-web-internal.yaml
+++ b/chart/templates/service-web-internal.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.webUI.enabled (eq .Values.persistence.mode "http") }}
+# Internal-only Service used by the collector Job to POST reports to the
+# dashboard's /internal/reports endpoint. Kept separate from the public
+# Service so an Ingress on `{fullname}-web` can never accidentally proxy
+# the internal port.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "provenance-collector.fullname" . }}-web-internal
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "provenance-collector.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web-internal
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.webUI.internalPort }}
+      targetPort: internal
+      protocol: TCP
+      name: internal
+  selector:
+    {{- include "provenance-collector.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -40,29 +40,35 @@ config:
   checkSBOM: true
   # Check for SLSA provenance attestations on discovered images.
   checkProvenance: true
-  # Report output type: "pvc" or "configmap".
-  reportOutput: "pvc"
-  # Filesystem path for PVC-based reports.
+  # Filesystem path used by the dashboard pod (and by the cron pod in pvc mode).
   reportPath: /reports
-  # How long to keep old reports. Use Go duration format (168h = 1 week).
-  # Set to "-1" to disable cleanup and keep all reports forever.
+  # How long the dashboard keeps old reports on disk. Use Go duration format
+  # (168h = 1 week). Set to "-1" to disable cleanup and keep all reports.
   reportRetention: "168h"
-  # ConfigMap name for configmap-based reports.
+  # ConfigMap name for configmap mode.
   reportConfigMap: provenance-report
   # Timeout for registry operations.
   registryTimeout: 30s
   # Cluster name included in report metadata (informational).
   clusterName: ""
+  # Timeout for uploading a report in http mode.
+  reportUploadTimeout: 30s
 
 # =============================================================================
 # Web Dashboard
 # =============================================================================
-# Optional web UI that shows provenance reports, timelines, and summaries.
-# Requires persistence.enabled=true (reads reports from the shared PVC).
+# Hosts the report UI and, in http mode, the internal upload endpoint that the
+# collector Job POSTs to. webUI.enabled must be true when persistence.mode=http.
 webUI:
-  enabled: false
+  enabled: true
   replicas: 1
+  # Public port (UI + read API: /, /api/reports, /api/reports/{filename}).
   port: 8080
+  # Internal port (POST /internal/reports, /healthz). Exposed only through
+  # the {fullname}-web-internal Service — never put this behind an Ingress.
+  internalPort: 8081
+  # Max body size (bytes) accepted on the internal upload endpoint.
+  uploadMaxBytes: 16777216  # 16 MiB
   resources:
     requests:
       cpu: 50m
@@ -97,12 +103,27 @@ webUI:
   manualJobTTL: "1h"
 
 # =============================================================================
-# Persistence (PVC for report storage)
+# Persistence
 # =============================================================================
+# mode controls how reports flow from collector → dashboard:
+#   http      — Collector POSTs the report to the dashboard's internal
+#               endpoint (cluster-DNS only). Dashboard owns a single PVC.
+#               No shared volume between pods. Default. Works on ReadWriteOnce
+#               storage classes like Hetzner's csi.hetzner.cloud.
+#   pvc       — Collector and dashboard share one PVC. Requires a
+#               ReadWriteMany-capable storageClass (Longhorn, NFS, EFS, …)
+#               unless every collector pod is guaranteed to land on the same
+#               node as the dashboard.
+#   configmap — Collector writes the report to a ConfigMap; the dashboard is
+#               not used. Useful for headless / inspection-only installs.
 persistence:
-  enabled: true
+  mode: http
+  # storageClass: required when mode=pvc; recommended when mode=http.
+  # Helm template rendering fails for mode=pvc if this is empty.
   storageClass: ""
   size: 1Gi
+  # accessModes only apply in pvc mode. For mode=pvc on a multi-node cluster
+  # you almost certainly want ReadWriteMany.
   accessModes:
     - ReadWriteOnce
 

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -15,6 +17,12 @@ import (
 
 	"github.com/nebari-dev/provenance-collector/internal/dashboard"
 	"github.com/nebari-dev/provenance-collector/internal/report"
+)
+
+const (
+	defaultPublicAddr   = ":8080"
+	defaultInternalAddr = ":8081"
+	defaultMaxUpload    = int64(16 << 20) // 16 MiB
 )
 
 func main() {
@@ -29,10 +37,18 @@ func main() {
 		reportsDir = "/reports"
 	}
 
-	addr := os.Getenv("PROVENANCE_DASHBOARD_ADDR")
-	if addr == "" {
-		addr = ":8080"
+	publicAddr := os.Getenv("PROVENANCE_DASHBOARD_ADDR")
+	if publicAddr == "" {
+		publicAddr = defaultPublicAddr
 	}
+
+	internalAddr := os.Getenv("PROVENANCE_DASHBOARD_INTERNAL_ADDR")
+	if internalAddr == "" {
+		internalAddr = defaultInternalAddr
+	}
+
+	retention := parseDuration("PROVENANCE_REPORT_RETENTION", 7*24*time.Hour)
+	maxUpload := parseBytes("PROVENANCE_UPLOAD_MAX_BYTES", defaultMaxUpload)
 
 	authCfg := dashboard.AuthConfig{
 		IssuerURL:   os.Getenv("PROVENANCE_OIDC_ISSUER"),
@@ -42,14 +58,18 @@ func main() {
 	manualJobTTL := parseManualJobTTL(os.Getenv("PROVENANCE_MANUAL_JOB_TTL"))
 
 	slog.Info("configuration loaded",
-		"addr", addr,
+		"publicAddr", publicAddr,
+		"internalAddr", internalAddr,
 		"reportsDir", reportsDir,
+		"retention", retention.String(),
+		"maxUploadBytes", maxUpload,
 		"authIssuer", authCfg.IssuerURL,
 		"adminGroups", len(authCfg.AdminGroups),
 		"manualJobTTL", manualJobTTL.String(),
 	)
 
-	srv := dashboard.NewServer(reportsDir).WithAuth(authCfg)
+	publicSrv := dashboard.NewServer(reportsDir).WithAuth(authCfg)
+	internalSrv := dashboard.NewInternalServer(reportsDir, retention, maxUpload)
 
 	// /api/scan needs an in-cluster client + the CronJob's namespace/name.
 	// Missing config or being out-of-cluster simply leaves the endpoint
@@ -61,16 +81,24 @@ func main() {
 			slog.Warn("scan endpoint disabled: kubernetes client unavailable",
 				"namespace", namespace, "cronJob", cronJobName, "error", err)
 		} else {
-			srv = srv.WithScanRunner(runner)
+			publicSrv = publicSrv.WithScanRunner(runner)
 			slog.Info("scan endpoint enabled",
 				"namespace", namespace, "cronJob", cronJobName)
 		}
 	}
 
-	httpServer := &http.Server{
-		Addr:         addr,
-		Handler:      srv,
+	publicHTTP := &http.Server{
+		Addr:         publicAddr,
+		Handler:      publicSrv,
 		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	internalHTTP := &http.Server{
+		Addr:         internalAddr,
+		Handler:      internalSrv,
+		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  60 * time.Second,
 	}
@@ -78,21 +106,35 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
+	serveErr := make(chan error, 2)
 	go func() {
-		slog.Info("starting dashboard", "addr", addr, "reports", reportsDir)
-		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			slog.Error("server failed", "error", err)
-			os.Exit(1)
+		slog.Info("public listener starting", "addr", publicAddr)
+		if err := publicHTTP.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serveErr <- err
+		}
+	}()
+	go func() {
+		slog.Info("internal listener starting", "addr", internalAddr)
+		if err := internalHTTP.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serveErr <- err
 		}
 	}()
 
-	<-ctx.Done()
-	slog.Info("shutting down dashboard")
+	select {
+	case <-ctx.Done():
+		slog.Info("shutdown signal received")
+	case err := <-serveErr:
+		slog.Error("listener failed", "error", err)
+		cancel()
+	}
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer shutdownCancel()
-	if err := httpServer.Shutdown(shutdownCtx); err != nil {
-		slog.Error("shutdown error", "error", err)
+	if err := publicHTTP.Shutdown(shutdownCtx); err != nil {
+		slog.Error("public shutdown error", "error", err)
+	}
+	if err := internalHTTP.Shutdown(shutdownCtx); err != nil {
+		slog.Error("internal shutdown error", "error", err)
 	}
 }
 
@@ -139,4 +181,31 @@ func splitAndTrim(s string) []string {
 		}
 	}
 	return out
+}
+
+func parseDuration(key string, fallback time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	if v == "-1" {
+		return -1
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return fallback
+	}
+	return d
+}
+
+func parseBytes(key string, fallback int64) int64 {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil || n <= 0 {
+		return fallback
+	}
+	return n
 }

--- a/cmd/provenance-collector/main.go
+++ b/cmd/provenance-collector/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -161,9 +162,17 @@ func run(ctx context.Context) error {
 	case "configmap":
 		slog.Info("writing report to configmap", "name", cfg.ReportConfigMap, "namespace", cfg.ReportConfigMapNamespace)
 		writer = report.NewConfigMapWriter(client, cfg.ReportConfigMap, cfg.ReportConfigMapNamespace)
-	default:
+	case "pvc":
 		slog.Info("writing report to filesystem", "path", cfg.ReportPath, "retention", cfg.ReportRetention)
 		writer = report.NewPVCWriter(cfg.ReportPath, cfg.ReportRetention)
+	case "http", "":
+		if cfg.ReportUploadURL == "" {
+			return fmt.Errorf("PROVENANCE_REPORT_UPLOAD_URL is required when PROVENANCE_REPORT_OUTPUT=http")
+		}
+		slog.Info("uploading report to dashboard", "url", cfg.ReportUploadURL, "timeout", cfg.ReportUploadTimeout)
+		writer = report.NewHTTPWriter(cfg.ReportUploadURL, cfg.ReportUploadTimeout)
+	default:
+		return fmt.Errorf("unknown PROVENANCE_REPORT_OUTPUT %q (expected http, pvc, or configmap)", cfg.ReportOutput)
 	}
 
 	if err := writer.Write(ctx, provReport); err != nil {

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -19,8 +19,8 @@ deploy: build-load
 		--set image.repository=provenance-collector \
 		--set image.tag=dev \
 		--set image.pullPolicy=Never \
-		--set config.reportOutput=configmap \
-		--set persistence.enabled=false \
+		--set persistence.mode=configmap \
+		--set webUI.enabled=false \
 		--set config.verifySignatures=false \
 		--set config.checkUpdates=false
 

--- a/examples/argocd-application.yaml
+++ b/examples/argocd-application.yaml
@@ -22,7 +22,9 @@ spec:
           verifySignatures: true
           helmEnabled: true
           checkUpdates: true
-          reportOutput: pvc
+
+        persistence:
+          mode: http  # http | pvc | configmap (see chart/values.yaml)
 
         webUI:
           enabled: true

--- a/examples/nebari-values.yaml
+++ b/examples/nebari-values.yaml
@@ -16,19 +16,23 @@ config:
   verifySignatures: true
   helmEnabled: true
   checkUpdates: true
-  reportOutput: pvc
   reportPath: /reports
   clusterName: ""  # Set to your cluster name.
 
 persistence:
-  enabled: true
+  # http mode is the safe default: only the dashboard pod mounts the volume,
+  # so a ReadWriteOnce class (e.g. Hetzner csi.hetzner.cloud) is fine.
+  mode: http
+  storageClass: ""
   size: 1Gi
 
-# Enable the web dashboard.
+# Required in http mode — hosts UI + internal upload endpoint.
 webUI:
   enabled: true
 
-# Register with the nebari-operator and expose through the gateway.
+# Register with the nebari-operator and expose the public UI through the gateway.
+# The internal upload Service ({fullname}-web-internal) is intentionally not
+# routed here: it must stay cluster-only.
 nebariapp:
   enabled: true
   hostname: provenance.example.com  # Replace with your hostname.

--- a/examples/standalone-values.yaml
+++ b/examples/standalone-values.yaml
@@ -15,16 +15,19 @@ config:
   verifySignatures: true
   helmEnabled: true
   checkUpdates: true
-  # Write reports to PVC.
-  reportOutput: pvc
   reportPath: /reports
   clusterName: my-cluster
 
 persistence:
-  enabled: true
+  # http: collector POSTs reports to the dashboard's internal endpoint.
+  # The dashboard owns the PVC; no shared volume between pods. Works on
+  # ReadWriteOnce storage classes like Hetzner csi.hetzner.cloud.
+  mode: http
+  storageClass: ""  # Optional, but recommended (uses the cluster default if empty).
   size: 1Gi
 
-# Enable the web dashboard (accessible via port-forward).
+# webUI is required in http mode — it hosts both the read API/UI and the
+# internal upload endpoint the collector POSTs to.
 webUI:
   enabled: true
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,16 +30,23 @@ type Config struct {
 	CheckSBOM bool
 	// Whether to check for SLSA provenance attestations on images.
 	CheckProvenance bool
-	// Report output type: "pvc" or "configmap".
+	// Report output type: "http" (POST to dashboard), "pvc" (write to local
+	// filesystem on a shared PVC), or "configmap".
 	ReportOutput string
 	// File path for PVC-based report output.
 	ReportPath string
 	// How long to keep old reports. Negative means keep forever.
+	// In http mode this is consumed by the dashboard, not the collector.
 	ReportRetention time.Duration
 	// ConfigMap name for configmap-based report output.
 	ReportConfigMap string
 	// Namespace for ConfigMap report output.
 	ReportConfigMapNamespace string
+	// Upload URL used in http mode (full URL including path, e.g.
+	// http://provenance-web-internal.namespace.svc:8081/internal/reports).
+	ReportUploadURL string
+	// Timeout for the upload request in http mode.
+	ReportUploadTimeout time.Duration
 	// Timeout for registry operations.
 	RegistryTimeout time.Duration
 	// Path to kubeconfig (empty = in-cluster).
@@ -62,11 +69,13 @@ func Load() *Config {
 		UpdateLevel:              envDefault("PROVENANCE_UPDATE_LEVEL", "patch"),
 		CheckSBOM:                envBool("PROVENANCE_CHECK_SBOM", true),
 		CheckProvenance:          envBool("PROVENANCE_CHECK_PROVENANCE", true),
-		ReportOutput:             envDefault("PROVENANCE_REPORT_OUTPUT", "pvc"),
+		ReportOutput:             envDefault("PROVENANCE_REPORT_OUTPUT", "http"),
 		ReportPath:               envDefault("PROVENANCE_REPORT_PATH", "/reports"),
 		ReportRetention:          envDuration("PROVENANCE_REPORT_RETENTION", 7*24*time.Hour),
 		ReportConfigMap:          envDefault("PROVENANCE_REPORT_CONFIGMAP", "provenance-report"),
 		ReportConfigMapNamespace: envDefault("PROVENANCE_REPORT_CONFIGMAP_NAMESPACE", "default"),
+		ReportUploadURL:          os.Getenv("PROVENANCE_REPORT_UPLOAD_URL"),
+		ReportUploadTimeout:      envDuration("PROVENANCE_REPORT_UPLOAD_TIMEOUT", 30*time.Second),
 		RegistryTimeout:          envDuration("PROVENANCE_REGISTRY_TIMEOUT", 30*time.Second),
 		Kubeconfig:               os.Getenv("KUBECONFIG"),
 		ClusterName:              os.Getenv("PROVENANCE_CLUSTER_NAME"),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,6 +12,7 @@ func TestLoadDefaults(t *testing.T) {
 		"PROVENANCE_VERIFY_SIGNATURES", "PROVENANCE_HELM_ENABLED",
 		"PROVENANCE_CHECK_UPDATES", "PROVENANCE_REPORT_OUTPUT",
 		"PROVENANCE_REPORT_PATH", "PROVENANCE_REGISTRY_TIMEOUT",
+		"PROVENANCE_REPORT_UPLOAD_URL", "PROVENANCE_REPORT_UPLOAD_TIMEOUT",
 	} {
 		t.Setenv(key, "")
 	}
@@ -27,8 +28,11 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.CheckUpdates != true {
 		t.Error("expected CheckUpdates=true by default")
 	}
-	if cfg.ReportOutput != "pvc" {
-		t.Errorf("expected ReportOutput=pvc, got %s", cfg.ReportOutput)
+	if cfg.ReportOutput != "http" {
+		t.Errorf("expected ReportOutput=http, got %s", cfg.ReportOutput)
+	}
+	if cfg.ReportUploadTimeout != 30*time.Second {
+		t.Errorf("expected ReportUploadTimeout=30s, got %s", cfg.ReportUploadTimeout)
 	}
 	if cfg.ReportPath != "/reports" {
 		t.Errorf("expected ReportPath=/reports, got %s", cfg.ReportPath)

--- a/internal/dashboard/internal_server.go
+++ b/internal/dashboard/internal_server.go
@@ -1,0 +1,84 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/nebari-dev/provenance-collector/internal/report"
+)
+
+// InternalServer exposes the dashboard's collector-facing endpoints. It must
+// be bound to a port that is only reachable from inside the cluster — never
+// fronted by an Ingress — because it accepts unauthenticated report uploads
+// from the collector Job. The boundary is the Service exposure, not a token.
+type InternalServer struct {
+	reportsDir string
+	retention  time.Duration
+	maxBytes   int64
+	mux        *http.ServeMux
+}
+
+// NewInternalServer creates the collector-facing HTTP handler. retention is
+// applied to existing files in reportsDir after each successful upload (a
+// negative duration disables pruning). maxBytes caps the request body so a
+// runaway collector can't fill the volume.
+func NewInternalServer(reportsDir string, retention time.Duration, maxBytes int64) *InternalServer {
+	s := &InternalServer{
+		reportsDir: reportsDir,
+		retention:  retention,
+		maxBytes:   maxBytes,
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/internal/reports", s.handleUpload)
+	mux.HandleFunc("/healthz", s.handleHealthz)
+	s.mux = mux
+	return s
+}
+
+func (s *InternalServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+func (s *InternalServer) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
+}
+
+func (s *InternalServer) handleUpload(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body := http.MaxBytesReader(w, r.Body, s.maxBytes)
+	data, err := io.ReadAll(body)
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+
+	var probe report.ProvenanceReport
+	if err := json.Unmarshal(data, &probe); err != nil {
+		slog.Warn("rejecting malformed upload", "error", err, "remote", r.RemoteAddr)
+		http.Error(w, "invalid report JSON", http.StatusBadRequest)
+		return
+	}
+
+	if err := report.WriteReportFiles(s.reportsDir, s.retention, data); err != nil {
+		slog.Error("failed to persist uploaded report", "error", err)
+		http.Error(w, "failed to persist report", http.StatusInternalServerError)
+		return
+	}
+
+	slog.Info("report uploaded",
+		"clusterName", probe.Metadata.ClusterName,
+		"totalImages", probe.Summary.TotalImages,
+		"remote", r.RemoteAddr,
+	)
+
+	w.WriteHeader(http.StatusAccepted)
+}

--- a/internal/dashboard/internal_server_test.go
+++ b/internal/dashboard/internal_server_test.go
@@ -1,0 +1,122 @@
+package dashboard
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestInternalServer_Upload(t *testing.T) {
+	dir := t.TempDir()
+	srv := NewInternalServer(dir, -1, 1<<20)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/reports", bytes.NewReader([]byte(testReport)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	latest, err := os.ReadFile(filepath.Join(dir, "provenance-latest.json"))
+	if err != nil {
+		t.Fatalf("expected provenance-latest.json to be written: %v", err)
+	}
+	if !bytes.Contains(latest, []byte(`"test-cluster"`)) {
+		t.Errorf("persisted report did not include cluster name; got %s", string(latest))
+	}
+
+	entries, _ := os.ReadDir(dir)
+	var timestamped int
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "provenance-") && e.Name() != "provenance-latest.json" {
+			timestamped++
+		}
+	}
+	if timestamped != 1 {
+		t.Errorf("expected 1 timestamped report, got %d", timestamped)
+	}
+}
+
+func TestInternalServer_RejectsGet(t *testing.T) {
+	srv := NewInternalServer(t.TempDir(), -1, 1<<20)
+	req := httptest.NewRequest(http.MethodGet, "/internal/reports", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+	if allow := w.Header().Get("Allow"); allow != http.MethodPost {
+		t.Errorf("expected Allow: POST, got %s", allow)
+	}
+}
+
+func TestInternalServer_RejectsMalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	srv := NewInternalServer(dir, -1, 1<<20)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/reports", bytes.NewReader([]byte("{not json")))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "provenance-latest.json")); !os.IsNotExist(err) {
+		t.Error("malformed upload should not have produced a latest report")
+	}
+}
+
+func TestInternalServer_EnforcesMaxBytes(t *testing.T) {
+	srv := NewInternalServer(t.TempDir(), -1, 16)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/reports", bytes.NewReader([]byte(testReport)))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for oversized body, got %d", w.Code)
+	}
+}
+
+func TestInternalServer_Healthz(t *testing.T) {
+	srv := NewInternalServer(t.TempDir(), -1, 1<<20)
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestInternalServer_Retention(t *testing.T) {
+	dir := t.TempDir()
+	old := filepath.Join(dir, "provenance-20240101-060000.json")
+	if err := os.WriteFile(old, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-10 * 24 * time.Hour)
+	if err := os.Chtimes(old, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := NewInternalServer(dir, 24*time.Hour, 1<<20)
+	req := httptest.NewRequest(http.MethodPost, "/internal/reports", bytes.NewReader([]byte(testReport)))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", w.Code)
+	}
+	if _, err := os.Stat(old); !os.IsNotExist(err) {
+		t.Error("expected old report to be pruned by retention")
+	}
+}

--- a/internal/report/writer.go
+++ b/internal/report/writer.go
@@ -1,9 +1,12 @@
 package report
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"time"
@@ -18,10 +21,61 @@ type Writer interface {
 	Write(ctx context.Context, report *ProvenanceReport) error
 }
 
+// WriteReportFiles persists pre-marshaled report JSON to basePath as a
+// timestamped file plus provenance-latest.json, and prunes files older than
+// retention. A negative retention disables pruning. The dashboard's internal
+// upload handler and PVCWriter share this primitive so the on-disk layout is
+// identical regardless of how the report arrived.
+func WriteReportFiles(basePath string, retention time.Duration, data []byte) error {
+	if err := os.MkdirAll(basePath, 0o755); err != nil {
+		return fmt.Errorf("creating report directory: %w", err)
+	}
+
+	filename := fmt.Sprintf("provenance-%s.json", time.Now().UTC().Format("20060102-150405"))
+	path := filepath.Join(basePath, filename)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("writing report to %s: %w", path, err)
+	}
+
+	latestPath := filepath.Join(basePath, "provenance-latest.json")
+	_ = os.Remove(latestPath)
+	if err := os.WriteFile(latestPath, data, 0o644); err != nil {
+		return fmt.Errorf("writing latest report: %w", err)
+	}
+
+	pruneOldReports(basePath, retention)
+	return nil
+}
+
+func pruneOldReports(basePath string, retention time.Duration) {
+	if retention < 0 {
+		return
+	}
+
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		return
+	}
+
+	cutoff := time.Now().Add(-retention)
+	for _, e := range entries {
+		if e.IsDir() || e.Name() == "provenance-latest.json" {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			_ = os.Remove(filepath.Join(basePath, e.Name()))
+		}
+	}
+}
+
 // PVCWriter writes reports as JSON files to a filesystem path (typically a PVC mount).
 type PVCWriter struct {
 	basePath  string
-	retention time.Duration // negative means keep forever
+	retention time.Duration
 }
 
 // NewPVCWriter creates a Writer that outputs to the filesystem.
@@ -32,57 +86,59 @@ func NewPVCWriter(basePath string, retention time.Duration) Writer {
 }
 
 func (w *PVCWriter) Write(_ context.Context, report *ProvenanceReport) error {
-	if err := os.MkdirAll(w.basePath, 0o755); err != nil {
-		return fmt.Errorf("creating report directory: %w", err)
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling report: %w", err)
 	}
+	return WriteReportFiles(w.basePath, w.retention, data)
+}
 
-	filename := fmt.Sprintf("provenance-%s.json", time.Now().UTC().Format("20060102-150405"))
-	path := filepath.Join(w.basePath, filename)
+// HTTPWriter uploads reports to the dashboard's internal upload endpoint over
+// in-cluster HTTP. Used in `http` output mode so the collector Job and the
+// dashboard don't need to share a PersistentVolume — only the dashboard pod
+// owns the reports volume, sidestepping multi-attach errors on RWO storage
+// classes like Hetzner's csi.hetzner.cloud.
+type HTTPWriter struct {
+	uploadURL string
+	client    *http.Client
+}
 
+// NewHTTPWriter creates a Writer that POSTs reports to uploadURL. The URL
+// must be the fully qualified path of the upload endpoint (e.g.
+// http://provenance-web-internal.namespace.svc:8081/internal/reports).
+func NewHTTPWriter(uploadURL string, timeout time.Duration) Writer {
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	return &HTTPWriter{
+		uploadURL: uploadURL,
+		client:    &http.Client{Timeout: timeout},
+	}
+}
+
+func (w *HTTPWriter) Write(ctx context.Context, report *ProvenanceReport) error {
 	data, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling report: %w", err)
 	}
 
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		return fmt.Errorf("writing report to %s: %w", path, err)
-	}
-
-	// Also write a "latest" copy for easy access
-	latestPath := filepath.Join(w.basePath, "provenance-latest.json")
-	_ = os.Remove(latestPath)
-	if err := os.WriteFile(latestPath, data, 0o644); err != nil {
-		return fmt.Errorf("writing latest report: %w", err)
-	}
-
-	w.pruneOldReports()
-
-	return nil
-}
-
-func (w *PVCWriter) pruneOldReports() {
-	if w.retention < 0 {
-		return
-	}
-
-	entries, err := os.ReadDir(w.basePath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.uploadURL, bytes.NewReader(data))
 	if err != nil {
-		return
+		return fmt.Errorf("building upload request: %w", err)
 	}
+	req.Header.Set("Content-Type", "application/json")
 
-	cutoff := time.Now().Add(-w.retention)
-	for _, e := range entries {
-		if e.IsDir() || e.Name() == "provenance-latest.json" {
-			continue
-		}
-		info, err := e.Info()
-		if err != nil {
-			continue
-		}
-		if info.ModTime().Before(cutoff) {
-			_ = os.Remove(filepath.Join(w.basePath, e.Name()))
-		}
+	resp, err := w.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("uploading report to %s: %w", w.uploadURL, err)
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("upload to %s returned %d: %s", w.uploadURL, resp.StatusCode, string(body))
+	}
+	return nil
 }
 
 // ConfigMapWriter writes reports as Kubernetes ConfigMaps.
@@ -124,7 +180,6 @@ func (w *ConfigMapWriter) Write(ctx context.Context, report *ProvenanceReport) e
 
 	existing, err := w.client.CoreV1().ConfigMaps(w.namespace).Get(ctx, w.name, metav1.GetOptions{})
 	if err != nil {
-		// Create new
 		_, err = w.client.CoreV1().ConfigMaps(w.namespace).Create(ctx, cm, metav1.CreateOptions{})
 		if err != nil {
 			return fmt.Errorf("creating configmap %s/%s: %w", w.namespace, w.name, err)
@@ -132,7 +187,6 @@ func (w *ConfigMapWriter) Write(ctx context.Context, report *ProvenanceReport) e
 		return nil
 	}
 
-	// Update existing
 	existing.Data = cm.Data
 	existing.Labels = cm.Labels
 	_, err = w.client.CoreV1().ConfigMaps(w.namespace).Update(ctx, existing, metav1.UpdateOptions{})

--- a/internal/report/writer.go
+++ b/internal/report/writer.go
@@ -132,7 +132,7 @@ func (w *HTTPWriter) Write(ctx context.Context, report *ProvenanceReport) error 
 	if err != nil {
 		return fmt.Errorf("uploading report to %s: %w", w.uploadURL, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))

--- a/internal/report/writer_test.go
+++ b/internal/report/writer_test.go
@@ -3,6 +3,9 @@ package report
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -141,6 +144,65 @@ func TestPVCWriter_RetentionKeepsLatest(t *testing.T) {
 	// provenance-latest.json is rewritten by Write, so it'll exist with new content
 	if _, err := os.Stat(latestFile); err != nil {
 		t.Error("expected provenance-latest.json to exist")
+	}
+}
+
+func TestHTTPWriter_Success(t *testing.T) {
+	var gotBody []byte
+	var gotContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/internal/reports" {
+			t.Errorf("expected /internal/reports, got %s", r.URL.Path)
+		}
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	writer := NewHTTPWriter(srv.URL+"/internal/reports", time.Second)
+	if err := writer.Write(context.Background(), testReport()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotContentType != "application/json" {
+		t.Errorf("expected application/json, got %s", gotContentType)
+	}
+	var report ProvenanceReport
+	if err := json.Unmarshal(gotBody, &report); err != nil {
+		t.Fatalf("upload body is not valid JSON: %v", err)
+	}
+	if report.Metadata.ClusterName != "test-cluster" {
+		t.Errorf("expected cluster name test-cluster, got %s", report.Metadata.ClusterName)
+	}
+}
+
+func TestHTTPWriter_NonSuccessStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer srv.Close()
+
+	writer := NewHTTPWriter(srv.URL+"/internal/reports", time.Second)
+	err := writer.Write(context.Background(), testReport())
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
+func TestHTTPWriter_Unreachable(t *testing.T) {
+	// Closed server — connection should fail.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL + "/internal/reports"
+	srv.Close()
+
+	writer := NewHTTPWriter(url, 200*time.Millisecond)
+	if err := writer.Write(context.Background(), testReport()); err == nil {
+		t.Fatal("expected error when upload endpoint is unreachable")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a new `persistence.mode: http` (default) that has the collector POST reports to the dashboard's internal endpoint, so only the dashboard pod mounts the reports PVC. This fixes `Multi-Attach error for volume` on RWO-only storage classes like Hetzner `csi.hetzner.cloud`, which surfaced on the Nebari OpenTeams AI cluster.
- Keeps the shared-PVC behavior as `persistence.mode: pvc` (opt-in). Chart rendering now fails with an explicit message if `storageClass` is empty in that mode.
- `configmap` mode is unchanged.

## Why

The chart mounted a single `ReadWriteOnce` PVC into both the dashboard Deployment and the collector CronJob (plus any `kubectl create job --from=cronjob/...` manual-run). When the cron pod scheduled to a different node than the dashboard, kubelet refused to attach the volume. Earlier targets were k3s and didn't show this — first non-k3s deploy (Hetzner) hit it. Same RWX limitation Amit found before.

## What changed

**Go**
- `internal/report/writer.go` — new `HTTPWriter` and a shared `WriteReportFiles` helper (timestamped file + `provenance-latest.json` + retention) reused by `PVCWriter` and the upload handler.
- `internal/dashboard/internal_server.go` — new `InternalServer` exposing `POST /internal/reports` with `http.MaxBytesReader` and JSON validation before persisting.
- `cmd/dashboard/main.go` — runs two `http.Server`s: public (`:8080`, UI + read API) and internal (`:8081`, upload).
- `cmd/provenance-collector/main.go` — adds `http` to the writer switch, fails fast when `PROVENANCE_REPORT_UPLOAD_URL` is unset.
- `internal/config/config.go` — new `ReportUploadURL`, `ReportUploadTimeout`. Default `ReportOutput` flips to `http`.

**Chart**
- `chart/values.yaml` — `persistence.mode: http | pvc | configmap`; `webUI.internalPort: 8081`; `webUI.uploadMaxBytes`. `webUI.enabled` defaults to `true` (required by `http` mode).
- `chart/templates/pvc.yaml` — validates `webUI.enabled` in `http` mode and `storageClass` in `pvc` mode with `{{ fail … }}`.
- `chart/templates/service-web-internal.yaml` (new) — ClusterIP Service for the internal port, separate from `{fullname}-web` so a public Ingress can't proxy it.
- `chart/templates/deployment-web.yaml` — `strategy: Recreate` when a PVC is mounted (avoids multi-attach during rollouts); mounts RW in `http`, RO in `pvc`.
- `chart/templates/cronjob.yaml` — PVC mount only in `pvc` mode; envFrom drives the upload URL in `http` mode.
- `chart/templates/configmap.yaml` — `PROVENANCE_REPORT_OUTPUT` derived from `persistence.mode`; injects the in-cluster upload URL when `mode=http`.
- `chart/templates/NOTES.txt` — mode-aware install hints.

**Docs / examples**
- `README.md` — new Storage modes table, refreshed config and values references, updated quickstart and "View the Report" sections.
- `examples/*`, `dev/Makefile`, `.github/workflows/test-integration.yaml` — migrated off `config.reportOutput` / `persistence.enabled`.

Manual-run pods inherit all of this for free (they clone the CronJob pod spec).

## Test plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `helm lint chart/`
- [x] `helm template` in `http` mode (default) — renders one PVC bound only to the dashboard, two Services, CronJob with envFrom carrying upload URL
- [x] `helm template` with `persistence.mode=pvc` — fails fast when `storageClass` is empty; renders shared PVC when storageClass is set
- [x] `helm template` with `persistence.mode=configmap` and `webUI.enabled=false` — renders only ServiceAccount, ClusterRole/Binding, ConfigMap, CronJob (no PVC, no Services, no Deployment)
- [x] `helm template` with `webUI.enabled=false` in `http` mode — fails fast with explanatory message
- [x] Trigger `manual-run` post-upgrade and confirm it lands in the dashboard

## Verified on a live cluster

Exercised against a Nebari cluster on Hetzner (csi.hetzner.cloud, the original failure mode for shared PVC):

- Dashboard pod runs `pr-13`, exposes two named container ports `http:8080` + `internal:8081`.
- Two Services exist: `<fullname>-web` (ClusterIP :8080, public-facing through the gateway) and `<fullname>-web-internal` (ClusterIP :8081, in-cluster only).
- CronJob jobTemplate carries **no** `reports` volume / volumeMount when `persistence.mode=http`. Confirmed on a freshly-created manual-run pod: only the SA-token projected volume is mounted.
- Manual run (`kubectl create job --from=cronjob/...`) completes with `phase: Succeeded`, and the dashboard's `/api/reports` count increments by one immediately after the pod terminates.
- Collector log on the run carries `reportOutput: "http"` and `"uploading report to dashboard" url=http://<fullname>-web-internal.<ns>.svc:8081/internal/reports`, followed by `"report written successfully"` — confirming the upload path, not a shared-PVC write.
- Run Scan button (from a previous PR) continues to work end-to-end against this mode — the button-created Job uses the same CronJob template, so it also uploads via HTTP and triggers an immediate refresh on the UI.

## Upgrade note for existing installs

The Deployment's `strategy.type` flips from `RollingUpdate` to `Recreate` whenever a PVC is mounted. Kubernetes refuses an in-place transition because the live Deployment still carries server-defaulted `rollingUpdate` sub-fields and validation rejects `Recreate` + `rollingUpdate` together (same constraint hits both client-side and server-side apply). Existing installations should sync this PR with a `Replace`-style apply (e.g. Argo `syncOptions: ["Replace=true"]`, `kubectl replace -f`, or by deleting the Deployment and letting the controller recreate it). Fresh installs are unaffected.