### PR TITLE
feat(dashboard): add admin-gated Run Scan button

### DIFF
--- a/chart/templates/deployment-web.yaml
+++ b/chart/templates/deployment-web.yaml
@@ -43,6 +43,20 @@ spec:
               value: {{ .Values.config.reportPath | quote }}
             - name: PROVENANCE_DASHBOARD_ADDR
               value: ":{{ .Values.webUI.port }}"
+            - name: PROVENANCE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: PROVENANCE_CRONJOB_NAME
+              value: {{ include "provenance-collector.fullname" . | quote }}
+            {{- with .Values.webUI.oidcIssuer }}
+            - name: PROVENANCE_OIDC_ISSUER
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.webUI.adminGroups }}
+            - name: PROVENANCE_ADMIN_GROUPS
+              value: {{ join "," . | quote }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.webUI.port }}

--- a/chart/templates/nebariapp.yaml
+++ b/chart/templates/nebariapp.yaml
@@ -32,6 +32,9 @@ spec:
     groups:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- if .forwardAccessToken }}
+    forwardAccessToken: true
+    {{- end }}
   {{- end }}
   {{- with .Values.nebariapp.landingPage }}
   landingPage:

--- a/chart/templates/role-web.yaml
+++ b/chart/templates/role-web.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.webUI.enabled .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "provenance-collector.fullname" . }}-web
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "provenance-collector.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+rules:
+  # Read the CronJob template that the manual scan is cloned from.
+  - apiGroups: ["batch"]
+    resources: ["cronjobs"]
+    verbs: ["get"]
+  # Create the one-shot Job triggered by the "Run Scan" button, plus
+  # list/get so the dashboard can report on active manual runs.
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "create"]
+{{- end }}

--- a/chart/templates/rolebinding-web.yaml
+++ b/chart/templates/rolebinding-web.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.webUI.enabled .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "provenance-collector.fullname" . }}-web
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "provenance-collector.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "provenance-collector.fullname" . }}-web
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "provenance-collector.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -70,9 +70,17 @@ webUI:
     limits:
       cpu: 200m
       memory: 128Mi
-  # OIDC issuer URL used by the dashboard to validate forwarded bearer tokens
-  # and look up the user's groups via the issuer's /userinfo endpoint. Required
-  # for the "Run Scan" button to be visible; leave empty to disable.
+  # Base URL the dashboard pod uses to call the issuer's /userinfo endpoint and
+  # resolve the caller's groups. Required for the "Run Scan" button to be
+  # visible; leave empty to disable.
+  #
+  # This is the URL the dashboard *calls* — it does not need to match the `iss`
+  # claim inside the user's token. The dashboard never validates `iss` itself;
+  # it forwards the bearer to userinfo and trusts the issuer to accept or
+  # reject it. So in split-horizon setups (external hostname for browsers,
+  # internal cluster DNS for backends) you point this at whichever URL the pod
+  # can actually reach.
+  #
   # Example (Nebari in-cluster Keycloak):
   #   http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari
   oidcIssuer: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -70,6 +70,17 @@ webUI:
     limits:
       cpu: 200m
       memory: 128Mi
+  # OIDC issuer URL used by the dashboard to validate forwarded bearer tokens
+  # and look up the user's groups via the issuer's /userinfo endpoint. Required
+  # for the "Run Scan" button to be visible; leave empty to disable.
+  # Example (Nebari in-cluster Keycloak):
+  #   http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari
+  oidcIssuer: ""
+  # Keycloak groups whose members are allowed to trigger a manual scan from the
+  # web UI. Empty disables the "Run Scan" button entirely. Group matching is
+  # exact and case-sensitive; use the same form Keycloak returns in the token
+  # (typically with a leading "/").
+  adminGroups: []
 
 # =============================================================================
 # Persistence (PVC for report storage)
@@ -145,6 +156,10 @@ nebariapp:
       - email
       - groups
     groups: []
+    # Forward the user's access token to the dashboard as
+    # `Authorization: Bearer <token>`. Required when webUI.adminGroups is set
+    # so the dashboard can resolve group membership from the token's issuer.
+    forwardAccessToken: false
   landingPage:
     enabled: false
     displayName: "Provenance Collector"

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -6,8 +6,12 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"github.com/nebari-dev/provenance-collector/internal/dashboard"
 	"github.com/nebari-dev/provenance-collector/internal/report"
@@ -30,12 +34,35 @@ func main() {
 		addr = ":8080"
 	}
 
+	authCfg := dashboard.AuthConfig{
+		IssuerURL:   os.Getenv("PROVENANCE_OIDC_ISSUER"),
+		AdminGroups: splitAndTrim(os.Getenv("PROVENANCE_ADMIN_GROUPS")),
+	}
+
 	slog.Info("configuration loaded",
 		"addr", addr,
 		"reportsDir", reportsDir,
+		"authIssuer", authCfg.IssuerURL,
+		"adminGroups", len(authCfg.AdminGroups),
 	)
 
-	srv := dashboard.NewServer(reportsDir)
+	srv := dashboard.NewServer(reportsDir).WithAuth(authCfg)
+
+	// /api/scan needs an in-cluster client + the CronJob's namespace/name.
+	// Missing config or being out-of-cluster simply leaves the endpoint
+	// disabled — handler will respond 503.
+	namespace := os.Getenv("PROVENANCE_NAMESPACE")
+	cronJobName := os.Getenv("PROVENANCE_CRONJOB_NAME")
+	if namespace != "" && cronJobName != "" {
+		if runner, err := buildScanRunner(namespace, cronJobName); err != nil {
+			slog.Warn("scan endpoint disabled: kubernetes client unavailable",
+				"namespace", namespace, "cronJob", cronJobName, "error", err)
+		} else {
+			srv = srv.WithScanRunner(runner)
+			slog.Info("scan endpoint enabled",
+				"namespace", namespace, "cronJob", cronJobName)
+		}
+	}
 
 	httpServer := &http.Server{
 		Addr:         addr,
@@ -64,4 +91,30 @@ func main() {
 	if err := httpServer.Shutdown(shutdownCtx); err != nil {
 		slog.Error("shutdown error", "error", err)
 	}
+}
+
+func buildScanRunner(namespace, cronJobName string) (dashboard.ScanRunner, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return dashboard.NewK8sScanRunner(client, namespace, cronJobName), nil
+}
+
+func splitAndTrim(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/internal/dashboard/auth.go
+++ b/internal/dashboard/auth.go
@@ -137,6 +137,14 @@ func (a *authenticator) cachePut(h string, id *Identity) {
 	a.cache[h] = cachedIdentity{id: id, expires: time.Now().Add(a.ttl)}
 }
 
+// fetchUserInfo treats the bearer as opaque and delegates validation to the
+// issuer's userinfo endpoint: Keycloak verifies the signature against its own
+// keys and returns claims, or rejects the request. We never inspect or check
+// the token's `iss` claim ourselves, so IssuerURL is just "where the dashboard
+// pod sends userinfo requests" — it does NOT need to equal the `iss` value in
+// the token. This matters in Nebari's split-horizon DNS setup, where tokens
+// minted via the external Keycloak hostname can still be validated by calling
+// the internal cluster-DNS Keycloak service.
 func (a *authenticator) fetchUserInfo(ctx context.Context, token string) (*Identity, error) {
 	url := a.issuerURL + "/protocol/openid-connect/userinfo"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)

--- a/internal/dashboard/auth.go
+++ b/internal/dashboard/auth.go
@@ -1,0 +1,203 @@
+package dashboard
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// AuthConfig wires the optional OIDC-backed authorization layer used to decide
+// whether the calling user may trigger a manual scan. When IssuerURL is empty
+// or AdminGroups is empty, the dashboard treats authorization as disabled:
+// /api/me reports canRunScan=false and /api/scan returns 503.
+type AuthConfig struct {
+	// IssuerURL is the OIDC issuer base (e.g. "https://kc/realms/nebari").
+	// The userinfo endpoint is derived as <IssuerURL>/protocol/openid-connect/userinfo.
+	IssuerURL string
+	// AdminGroups is the list of groups whose members may trigger a scan.
+	// Matched exactly against the values in the userinfo `groups` claim.
+	AdminGroups []string
+	// HTTPClient is the client used to call /userinfo. Defaults to a client
+	// with a 5s timeout.
+	HTTPClient *http.Client
+	// CacheTTL controls how long a userinfo response is cached per token.
+	// Defaults to 60s.
+	CacheTTL time.Duration
+}
+
+// Identity is the subset of userinfo claims the dashboard cares about.
+type Identity struct {
+	Subject string   `json:"sub,omitempty"`
+	Email   string   `json:"email,omitempty"`
+	Groups  []string `json:"groups,omitempty"`
+}
+
+type cachedIdentity struct {
+	id      *Identity
+	expires time.Time
+}
+
+type authenticator struct {
+	issuerURL   string
+	adminGroups map[string]struct{}
+	client      *http.Client
+	ttl         time.Duration
+
+	mu    sync.Mutex
+	cache map[string]cachedIdentity
+}
+
+func newAuthenticator(cfg AuthConfig) *authenticator {
+	a := &authenticator{
+		issuerURL:   strings.TrimRight(cfg.IssuerURL, "/"),
+		adminGroups: make(map[string]struct{}, len(cfg.AdminGroups)),
+		client:      cfg.HTTPClient,
+		ttl:         cfg.CacheTTL,
+		cache:       make(map[string]cachedIdentity),
+	}
+	for _, g := range cfg.AdminGroups {
+		if g = strings.TrimSpace(g); g != "" {
+			a.adminGroups[g] = struct{}{}
+		}
+	}
+	if a.client == nil {
+		a.client = &http.Client{Timeout: 5 * time.Second}
+	}
+	if a.ttl == 0 {
+		a.ttl = 60 * time.Second
+	}
+	return a
+}
+
+// enabled reports whether the authenticator has enough configuration to make
+// an admin-group decision. Nil-safe.
+func (a *authenticator) enabled() bool {
+	return a != nil && a.issuerURL != "" && len(a.adminGroups) > 0
+}
+
+// identify resolves the caller's identity from the request's bearer token,
+// using the configured OIDC userinfo endpoint. Returns nil when auth is
+// disabled, when no token is present, or when validation fails. Errors fail
+// closed — we never grant scan access based on an unverifiable token.
+func (a *authenticator) identify(ctx context.Context, r *http.Request) *Identity {
+	if a == nil || a.issuerURL == "" {
+		return nil
+	}
+	token := bearerFrom(r)
+	if token == "" {
+		return nil
+	}
+	h := tokenHash(token)
+	if id := a.cacheGet(h); id != nil {
+		return id
+	}
+	id, err := a.fetchUserInfo(ctx, token)
+	if err != nil {
+		return nil
+	}
+	a.cachePut(h, id)
+	return id
+}
+
+// canRunScan returns true iff the identity is a member of at least one
+// configured admin group. Nil-safe.
+func (a *authenticator) canRunScan(id *Identity) bool {
+	if !a.enabled() || id == nil {
+		return false
+	}
+	for _, g := range id.Groups {
+		if _, ok := a.adminGroups[g]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *authenticator) cacheGet(h string) *Identity {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	c, ok := a.cache[h]
+	if !ok || time.Now().After(c.expires) {
+		delete(a.cache, h)
+		return nil
+	}
+	return c.id
+}
+
+func (a *authenticator) cachePut(h string, id *Identity) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.cache[h] = cachedIdentity{id: id, expires: time.Now().Add(a.ttl)}
+}
+
+func (a *authenticator) fetchUserInfo(ctx context.Context, token string) (*Identity, error) {
+	url := a.issuerURL + "/protocol/openid-connect/userinfo"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("userinfo: %s: %s", resp.Status, body)
+	}
+	var raw struct {
+		Sub    string          `json:"sub"`
+		Email  string          `json:"email"`
+		Groups json.RawMessage `json:"groups"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, err
+	}
+	groups, _ := parseGroupsClaim(raw.Groups)
+	return &Identity{Subject: raw.Sub, Email: raw.Email, Groups: groups}, nil
+}
+
+// parseGroupsClaim normalizes the `groups` claim, which Keycloak emits in a
+// few different shapes depending on the protocol-mapper configuration:
+// a string array, a single string, or absent. We accept all three.
+func parseGroupsClaim(raw json.RawMessage) ([]string, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var arr []string
+	if err := json.Unmarshal(raw, &arr); err == nil {
+		return arr, nil
+	}
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		return []string{single}, nil
+	}
+	return nil, fmt.Errorf("unrecognized groups claim shape")
+}
+
+func bearerFrom(r *http.Request) string {
+	h := r.Header.Get("Authorization")
+	if h == "" {
+		return ""
+	}
+	parts := strings.SplitN(h, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return ""
+	}
+	return strings.TrimSpace(parts[1])
+}
+
+// tokenHash hashes the bearer for use as a cache key. The cache never stores
+// the raw token.
+func tokenHash(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/dashboard/auth.go
+++ b/internal/dashboard/auth.go
@@ -156,7 +156,7 @@ func (a *authenticator) fetchUserInfo(ctx context.Context, token string) (*Ident
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		return nil, fmt.Errorf("userinfo: %s: %s", resp.Status, body)

--- a/internal/dashboard/auth_test.go
+++ b/internal/dashboard/auth_test.go
@@ -1,0 +1,231 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// userInfoStub stands in for Keycloak's /protocol/openid-connect/userinfo.
+// Tokens map to canned responses; an unknown token returns 401.
+func userInfoStub(t *testing.T, responses map[string]string, hits *int32) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/protocol/openid-connect/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		if hits != nil {
+			atomic.AddInt32(hits, 1)
+		}
+		h := r.Header.Get("Authorization")
+		if !strings.HasPrefix(h, "Bearer ") {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		token := strings.TrimPrefix(h, "Bearer ")
+		body, ok := responses[token]
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestMe_AuthDisabled(t *testing.T) {
+	srv := NewServer(t.TempDir())
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp meResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+	if resp.AuthEnabled {
+		t.Errorf("expected authEnabled=false when no issuer configured")
+	}
+	if resp.CanRunScan {
+		t.Errorf("expected canRunScan=false")
+	}
+}
+
+func TestMe_NoBearer(t *testing.T) {
+	stub := userInfoStub(t, nil, nil)
+	defer stub.Close()
+
+	srv := NewServer(t.TempDir()).WithAuth(AuthConfig{
+		IssuerURL:   stub.URL,
+		AdminGroups: []string{"/admins"},
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp meResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if !resp.AuthEnabled {
+		t.Errorf("expected authEnabled=true")
+	}
+	if resp.CanRunScan {
+		t.Errorf("expected canRunScan=false without bearer")
+	}
+}
+
+func TestMe_AdminGroup(t *testing.T) {
+	stub := userInfoStub(t, map[string]string{
+		"admin-token": `{"sub":"u1","email":"a@x","groups":["/admins","/users"]}`,
+	}, nil)
+	defer stub.Close()
+
+	srv := NewServer(t.TempDir()).WithAuth(AuthConfig{
+		IssuerURL:   stub.URL,
+		AdminGroups: []string{"/admins"},
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	req.Header.Set("Authorization", "Bearer admin-token")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	var resp meResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if !resp.CanRunScan {
+		t.Errorf("expected canRunScan=true for /admins member, got %+v", resp)
+	}
+	if resp.Email != "a@x" {
+		t.Errorf("expected email a@x, got %q", resp.Email)
+	}
+}
+
+func TestMe_NonAdminGroup(t *testing.T) {
+	stub := userInfoStub(t, map[string]string{
+		"user-token": `{"sub":"u2","email":"u@x","groups":["/users"]}`,
+	}, nil)
+	defer stub.Close()
+
+	srv := NewServer(t.TempDir()).WithAuth(AuthConfig{
+		IssuerURL:   stub.URL,
+		AdminGroups: []string{"/admins"},
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	req.Header.Set("Authorization", "Bearer user-token")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	var resp meResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.CanRunScan {
+		t.Errorf("non-admin user should not see canRunScan=true: %+v", resp)
+	}
+	// Identity should still surface for the UI to show who's logged in.
+	if resp.Email != "u@x" {
+		t.Errorf("expected email u@x, got %q", resp.Email)
+	}
+}
+
+func TestMe_InvalidToken(t *testing.T) {
+	stub := userInfoStub(t, map[string]string{}, nil) // every token 401s
+	defer stub.Close()
+
+	srv := NewServer(t.TempDir()).WithAuth(AuthConfig{
+		IssuerURL:   stub.URL,
+		AdminGroups: []string{"/admins"},
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	req.Header.Set("Authorization", "Bearer bogus")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	var resp meResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.CanRunScan {
+		t.Errorf("expected canRunScan=false when userinfo returns 401")
+	}
+	if resp.Email != "" {
+		t.Errorf("expected no email on failed validation, got %q", resp.Email)
+	}
+}
+
+func TestUserInfo_Cached(t *testing.T) {
+	var hits int32
+	stub := userInfoStub(t, map[string]string{
+		"admin-token": `{"sub":"u1","email":"a@x","groups":["/admins"]}`,
+	}, &hits)
+	defer stub.Close()
+
+	a := newAuthenticator(AuthConfig{
+		IssuerURL:   stub.URL,
+		AdminGroups: []string{"/admins"},
+		CacheTTL:    50 * time.Millisecond,
+	})
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer admin-token")
+
+	for range 3 {
+		_ = a.identify(r.Context(), r)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Errorf("expected 1 userinfo call within TTL, got %d", got)
+	}
+
+	time.Sleep(80 * time.Millisecond)
+	_ = a.identify(r.Context(), r)
+	if got := atomic.LoadInt32(&hits); got != 2 {
+		t.Errorf("expected 2 userinfo calls after TTL expiry, got %d", got)
+	}
+}
+
+func TestParseGroupsClaim(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"array", `["a","b"]`, []string{"a", "b"}},
+		{"single string", `"only"`, []string{"only"}},
+		{"null", `null`, nil},
+		{"empty", ``, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := parseGroupsClaim([]byte(tc.raw))
+			if len(got) != len(tc.want) {
+				t.Fatalf("len mismatch: got %v want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("idx %d: got %q want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBearerFrom(t *testing.T) {
+	cases := map[string]string{
+		"":               "",
+		"Bearer abc":     "abc",
+		"bearer xyz":     "xyz",
+		"Basic foo":      "",
+		"Bearer  spaces": "spaces",
+	}
+	for h, want := range cases {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		if h != "" {
+			r.Header.Set("Authorization", h)
+		}
+		if got := bearerFrom(r); got != want {
+			t.Errorf("header %q: got %q want %q", h, got, want)
+		}
+	}
+}

--- a/internal/dashboard/index.go
+++ b/internal/dashboard/index.go
@@ -142,6 +142,21 @@ const indexHTML = `<!DOCTYPE html>
   .detail-status-text { font-size: 12px; }
   .detail-status-text .sub { font-size: 11px; color: var(--faint); margin-top: 1px; }
 
+  /* Run Scan button */
+  .btn-scan { background: var(--purple-bg); border: 1px solid var(--purple-dark); border-radius: var(--radius-sm); padding: 5px 12px; color: var(--purple); font-size: 12px; font-family: var(--font); font-weight: 500; cursor: pointer; transition: all 0.15s ease; display: inline-flex; align-items: center; gap: 6px; }
+  .btn-scan:hover:not(:disabled) { background: var(--purple-dark); color: white; }
+  .btn-scan:disabled { opacity: 0.5; cursor: progress; }
+  .btn-scan .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--purple); box-shadow: 0 0 6px rgba(167,139,250,0.6); }
+  .btn-scan:hover:not(:disabled) .dot { background: white; box-shadow: 0 0 6px rgba(255,255,255,0.6); }
+
+  /* Toast */
+  .toast-wrap { position: fixed; bottom: 20px; right: 20px; z-index: 300; display: flex; flex-direction: column; gap: 8px; max-width: 420px; }
+  .toast { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--purple); border-radius: var(--radius-sm); padding: 10px 14px; font-size: 12px; color: var(--text); box-shadow: 0 4px 12px rgba(0,0,0,0.4); animation: slidein 0.2s ease; }
+  .toast.error { border-left-color: var(--red); }
+  .toast.success { border-left-color: var(--green); }
+  .toast .sub { font-size: 11px; color: var(--muted); margin-top: 2px; font-family: var(--mono); }
+  @keyframes slidein { from { transform: translateX(100%); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+
   /* Misc */
   .empty { text-align: center; padding: 40px 20px; color: var(--muted); }
   .empty p { margin-top: 4px; font-size: 12px; }
@@ -164,6 +179,9 @@ const indexHTML = `<!DOCTYPE html>
     <div class="nav-meta">
       <span id="cluster-name"></span>
       <span id="last-updated"></span>
+      <button id="btn-scan" class="btn-scan" style="display:none" onclick="runScan()" title="Trigger a manual provenance scan">
+        <span class="dot"></span><span>Run Scan</span>
+      </button>
     </div>
   </div>
 </nav>
@@ -196,6 +214,8 @@ const indexHTML = `<!DOCTYPE html>
   </div>
 </div>
 
+<div class="toast-wrap" id="toast-wrap"></div>
+
 <div class="detail-overlay" id="detail-overlay" onclick="closeDetail()"></div>
 <div class="detail-panel" id="detail-panel">
   <button class="detail-close" onclick="closeDetail()">&times;</button>
@@ -214,6 +234,7 @@ let currentPage = 0;
 let lastFilteredImages = [];
 
 async function init() {
+  initAuth();
   try {
     const res = await fetch('/api/reports');
     reports = await res.json();
@@ -223,6 +244,95 @@ async function init() {
   } catch (e) {
     document.getElementById('stats').innerHTML = '<div class="empty"><p>Failed to load reports</p></div>';
   }
+}
+
+// initAuth resolves whether the calling user may trigger a scan and shows
+// the Run Scan button if so. Fail-quiet: if /api/me errors, the button stays
+// hidden — better silent than wrongly inviting non-admins to a 403.
+async function initAuth() {
+  try {
+    const res = await fetch('/api/me');
+    if (!res.ok) return;
+    const me = await res.json();
+    if (me && me.canRunScan) {
+      document.getElementById('btn-scan').style.display = 'inline-flex';
+    }
+  } catch (e) { /* keep button hidden */ }
+}
+
+let scanPollTimer = null;
+const SCAN_POLL_MS = 5000;
+const SCAN_POLL_MAX = 60; // 5 minutes worst case
+
+async function runScan() {
+  const btn = document.getElementById('btn-scan');
+  btn.disabled = true;
+  btn.querySelector('span:last-child').textContent = 'Starting...';
+  try {
+    const res = await fetch('/api/scan', { method: 'POST' });
+    const text = await res.text();
+    if (!res.ok) {
+      showToast('error', 'Scan request failed', res.status + ' ' + (text || res.statusText));
+      return;
+    }
+    let body = {};
+    try { body = JSON.parse(text); } catch (e) {}
+    showToast('success', 'Scan started', body.jobName ? 'Job: ' + body.jobName : '');
+    btn.querySelector('span:last-child').textContent = 'Scan running';
+    pollForNewReport();
+  } catch (e) {
+    showToast('error', 'Scan request failed', String(e));
+  } finally {
+    // Re-enable after the poller decides we're done; until then keep disabled.
+    if (!scanPollTimer) {
+      btn.disabled = false;
+      btn.querySelector('span:last-child').textContent = 'Run Scan';
+    }
+  }
+}
+
+function pollForNewReport() {
+  const baselineCount = reports.length;
+  let ticks = 0;
+  const tick = async () => {
+    ticks++;
+    try {
+      const res = await fetch('/api/reports');
+      const latest = await res.json();
+      if (latest && latest.length > baselineCount) {
+        // New report landed — refresh UI and stop polling.
+        reports = latest;
+        renderTimeline();
+        await loadReport(reports[0].filename);
+        showToast('success', 'New report available', reports[0].filename);
+        finishScanPolling();
+        return;
+      }
+    } catch (e) { /* keep polling */ }
+    if (ticks >= SCAN_POLL_MAX) {
+      showToast('error', 'Scan still running', 'Stopped watching after ' + (SCAN_POLL_MAX * SCAN_POLL_MS / 60000) + ' min — refresh later');
+      finishScanPolling();
+      return;
+    }
+    scanPollTimer = setTimeout(tick, SCAN_POLL_MS);
+  };
+  scanPollTimer = setTimeout(tick, SCAN_POLL_MS);
+}
+
+function finishScanPolling() {
+  if (scanPollTimer) { clearTimeout(scanPollTimer); scanPollTimer = null; }
+  const btn = document.getElementById('btn-scan');
+  btn.disabled = false;
+  btn.querySelector('span:last-child').textContent = 'Run Scan';
+}
+
+function showToast(kind, title, sub) {
+  const wrap = document.getElementById('toast-wrap');
+  const el = document.createElement('div');
+  el.className = 'toast ' + (kind || '');
+  el.innerHTML = '<div>' + esc(title) + '</div>' + (sub ? '<div class="sub">' + esc(sub) + '</div>' : '');
+  wrap.appendChild(el);
+  setTimeout(() => { el.style.transition = 'opacity 0.3s'; el.style.opacity = '0'; setTimeout(() => el.remove(), 300); }, 6000);
 }
 
 function showEmpty() {

--- a/internal/dashboard/scan.go
+++ b/internal/dashboard/scan.go
@@ -1,0 +1,170 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// ScanRunner abstracts the side effects of /api/scan so tests can swap in a
+// fake without standing up an apiserver.
+type ScanRunner interface {
+	// HasActiveManualJob reports whether a Job owned by the watched CronJob
+	// is currently active (not yet completed or failed).
+	HasActiveManualJob(ctx context.Context) (bool, error)
+	// StartManualScan creates a new one-shot Job from the watched CronJob's
+	// jobTemplate and returns the new Job's name.
+	StartManualScan(ctx context.Context) (string, error)
+}
+
+// k8sScanRunner is the production ScanRunner: it talks to a real apiserver
+// via client-go to inspect and create Jobs from a specific CronJob.
+type k8sScanRunner struct {
+	client    kubernetes.Interface
+	namespace string
+	cronJob   string
+}
+
+// NewK8sScanRunner builds a ScanRunner backed by the provided clientset.
+// Exported so cmd/dashboard can wire it from an in-cluster config.
+func NewK8sScanRunner(client kubernetes.Interface, namespace, cronJob string) ScanRunner {
+	return &k8sScanRunner{client: client, namespace: namespace, cronJob: cronJob}
+}
+
+func (k *k8sScanRunner) HasActiveManualJob(ctx context.Context) (bool, error) {
+	jobs, err := k.client.BatchV1().Jobs(k.namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+	for _, j := range jobs.Items {
+		if !ownedBy(j.OwnerReferences, "CronJob", k.cronJob) {
+			continue
+		}
+		// Active counts pods currently running. A freshly created Job may
+		// have Active=0 for a heartbeat before pods spin up, so also treat
+		// a Job with no terminal state as in-flight.
+		if j.Status.Active > 0 {
+			return true, nil
+		}
+		if j.Status.CompletionTime == nil && j.Status.Failed == 0 && j.Status.Succeeded == 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (k *k8sScanRunner) StartManualScan(ctx context.Context) (string, error) {
+	cj, err := k.client.BatchV1().CronJobs(k.namespace).Get(ctx, k.cronJob, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	name := fmt.Sprintf("manual-%d", time.Now().Unix())
+	yes := true
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: k.namespace,
+			Labels:    cj.Spec.JobTemplate.Labels,
+			Annotations: map[string]string{
+				// Same annotation `kubectl create job --from=cronjob/...` sets.
+				"cronjob.kubernetes.io/instantiate": "manual",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         "batch/v1",
+				Kind:               "CronJob",
+				Name:               cj.Name,
+				UID:                cj.UID,
+				Controller:         &yes,
+				BlockOwnerDeletion: &yes,
+			}},
+		},
+		Spec: cj.Spec.JobTemplate.Spec,
+	}
+	created, err := k.client.BatchV1().Jobs(k.namespace).Create(ctx, job, metav1.CreateOptions{})
+	if err != nil {
+		return "", err
+	}
+	return created.Name, nil
+}
+
+func ownedBy(refs []metav1.OwnerReference, kind, name string) bool {
+	for _, o := range refs {
+		if o.Kind == kind && o.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// scanResponse is the JSON shape returned by a successful POST /api/scan.
+type scanResponse struct {
+	JobName   string `json:"jobName"`
+	Namespace string `json:"namespace"`
+}
+
+func (s *Server) handleScan(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !s.auth.enabled() {
+		http.Error(w, "scan endpoint is not configured (oidcIssuer/adminGroups unset)", http.StatusServiceUnavailable)
+		return
+	}
+	id := s.auth.identify(r.Context(), r)
+	if !s.auth.canRunScan(id) {
+		http.Error(w, "forbidden: caller is not in an admin group", http.StatusForbidden)
+		return
+	}
+	if s.scan == nil {
+		http.Error(w, "scan endpoint is not configured (kubernetes client unavailable)", http.StatusServiceUnavailable)
+		return
+	}
+
+	active, err := s.scan.HasActiveManualJob(r.Context())
+	if err != nil {
+		http.Error(w, "failed to inspect running jobs: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	if active {
+		http.Error(w, "a scan job is already active for this collector", http.StatusConflict)
+		return
+	}
+
+	name, err := s.scan.StartManualScan(r.Context())
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			http.Error(w, "scan request canceled", http.StatusGatewayTimeout)
+			return
+		}
+		http.Error(w, "failed to start scan: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(scanResponse{
+		JobName:   name,
+		Namespace: namespaceOf(s.scan),
+	})
+}
+
+// namespaceOf surfaces the namespace from a ScanRunner for the response body
+// without leaking the concrete type. Returns "" for runners that don't expose
+// one (e.g. test fakes that don't need it).
+func namespaceOf(r ScanRunner) string {
+	if k, ok := r.(*k8sScanRunner); ok {
+		return k.namespace
+	}
+	if n, ok := r.(interface{ Namespace() string }); ok {
+		return n.Namespace()
+	}
+	return ""
+}

--- a/internal/dashboard/scan.go
+++ b/internal/dashboard/scan.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
-	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -47,17 +46,29 @@ func (k *k8sScanRunner) HasActiveManualJob(ctx context.Context) (bool, error) {
 		if !ownedBy(j.OwnerReferences, "CronJob", k.cronJob) {
 			continue
 		}
-		// Active counts pods currently running. A freshly created Job may
-		// have Active=0 for a heartbeat before pods spin up, so also treat
-		// a Job with no terminal state as in-flight.
-		if j.Status.Active > 0 {
-			return true, nil
-		}
-		if j.Status.CompletionTime == nil && j.Status.Failed == 0 && j.Status.Succeeded == 0 {
+		if !jobDone(j.Status.Conditions) {
 			return true, nil
 		}
 	}
 	return false, nil
+}
+
+// jobDone reports whether a Job has reached a terminal state. The Job
+// controller writes a Complete or Failed condition exactly once when the
+// Job stops progressing; checking conditions is more reliable than
+// inspecting Active/Succeeded/Failed counters, which all read zero in the
+// brief window between the last pod being collected and the condition being
+// written (and, post-Kubernetes 1.28, CompletionTime is only set on success).
+func jobDone(conds []batchv1.JobCondition) bool {
+	for _, c := range conds {
+		if c.Status != corev1.ConditionTrue {
+			continue
+		}
+		if c.Type == batchv1.JobComplete || c.Type == batchv1.JobFailed {
+			return true
+		}
+	}
+	return false
 }
 
 func (k *k8sScanRunner) StartManualScan(ctx context.Context) (string, error) {
@@ -65,13 +76,15 @@ func (k *k8sScanRunner) StartManualScan(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	name := fmt.Sprintf("manual-%d", time.Now().Unix())
 	yes := true
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: k.namespace,
-			Labels:    cj.Spec.JobTemplate.Labels,
+			// GenerateName lets the apiserver pick a unique suffix so two
+			// admin clicks within the same TOCTOU window cannot collide on
+			// the same Job name.
+			GenerateName: "manual-",
+			Namespace:    k.namespace,
+			Labels:       cj.Spec.JobTemplate.Labels,
 			Annotations: map[string]string{
 				// Same annotation `kubectl create job --from=cronjob/...` sets.
 				"cronjob.kubernetes.io/instantiate": "manual",
@@ -113,6 +126,18 @@ func (s *Server) handleScan(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	// CSRF defense. With forwardAccessToken on, the gateway injects the
+	// bearer from the user's session cookie on every upstream request, so a
+	// cross-origin form POST landing here is already authenticated.
+	// Sec-Fetch-Site is on the browser's forbidden-header list (sites can't
+	// forge it via fetch()/XHR), so requiring `same-origin` blocks the
+	// cross-site case. Fail closed when the header is missing: old browsers
+	// and curl-style clients don't send it, and this endpoint is only meant
+	// to be triggered from the dashboard UI.
+	if r.Header.Get("Sec-Fetch-Site") != "same-origin" {
+		http.Error(w, "cross-origin requests not allowed", http.StatusForbidden)
 		return
 	}
 	if !s.auth.enabled() {

--- a/internal/dashboard/scan_test.go
+++ b/internal/dashboard/scan_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -13,6 +14,17 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 )
+
+// scanReq builds a same-origin POST to /api/scan with an optional bearer.
+// All /api/scan tests must go through this so they pass the CSRF gate.
+func scanReq(bearer string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/api/scan", nil)
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	return req
+}
 
 const (
 	testNamespace = "provenance-system"
@@ -97,7 +109,31 @@ func TestHasActiveManualJob(t *testing.T) {
 				Controller: &yes,
 			}},
 		},
-		Status: batchv1.JobStatus{Succeeded: 1, CompletionTime: &metav1.Time{}},
+		Status: batchv1.JobStatus{
+			Succeeded:      1,
+			CompletionTime: &metav1.Time{},
+			Conditions: []batchv1.JobCondition{
+				{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	failedJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "manual-98",
+			Namespace: testNamespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "batch/v1", Kind: "CronJob", Name: testCronName, UID: "cj-uid-1",
+				Controller: &yes,
+			}},
+		},
+		// Mirrors what the Job controller writes when backoffLimit is
+		// exhausted: Failed > 0, no CompletionTime, but a Failed condition.
+		Status: batchv1.JobStatus{
+			Failed: 3,
+			Conditions: []batchv1.JobCondition{
+				{Type: batchv1.JobFailed, Status: corev1.ConditionTrue},
+			},
+		},
 	}
 
 	t.Run("active", func(t *testing.T) {
@@ -121,6 +157,18 @@ func TestHasActiveManualJob(t *testing.T) {
 		}
 		if got {
 			t.Error("expected HasActiveManualJob=false when only completed job exists")
+		}
+	})
+
+	t.Run("only failed", func(t *testing.T) {
+		c := fake.NewClientset(makeCronJob(), failedJob)
+		runner := NewK8sScanRunner(c, testNamespace, testCronName)
+		got, err := runner.HasActiveManualJob(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got {
+			t.Error("expected HasActiveManualJob=false when only hard-failed job exists (regression guard for the heuristic that ignored Failed conditions)")
 		}
 	})
 
@@ -181,9 +229,8 @@ func TestScan_RequiresPOST(t *testing.T) {
 
 func TestScan_AuthDisabled(t *testing.T) {
 	srv := NewServer(t.TempDir()) // no auth wired
-	req := httptest.NewRequest(http.MethodPost, "/api/scan", nil)
 	w := httptest.NewRecorder()
-	srv.ServeHTTP(w, req)
+	srv.ServeHTTP(w, scanReq(""))
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("expected 503 with no auth configured, got %d", w.Code)
 	}
@@ -198,10 +245,8 @@ func TestScan_NoRunner(t *testing.T) {
 		WithAuth(AuthConfig{IssuerURL: stub.URL, AdminGroups: []string{"/admins"}})
 	// note: no WithScanRunner
 
-	req := httptest.NewRequest(http.MethodPost, "/api/scan", nil)
-	req.Header.Set("Authorization", "Bearer admin")
 	w := httptest.NewRecorder()
-	srv.ServeHTTP(w, req)
+	srv.ServeHTTP(w, scanReq("admin"))
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("expected 503 with no runner wired, got %d", w.Code)
 	}
@@ -210,10 +255,8 @@ func TestScan_NoRunner(t *testing.T) {
 func TestScan_Forbidden(t *testing.T) {
 	runner := &fakeRunner{startName: "manual-1"}
 	srv := newAdminSrv(t, runner)
-	req := httptest.NewRequest(http.MethodPost, "/api/scan", nil)
-	req.Header.Set("Authorization", "Bearer user") // non-admin
 	w := httptest.NewRecorder()
-	srv.ServeHTTP(w, req)
+	srv.ServeHTTP(w, scanReq("user")) // non-admin token
 	if w.Code != http.StatusForbidden {
 		t.Errorf("expected 403 for non-admin, got %d", w.Code)
 	}
@@ -224,21 +267,48 @@ func TestScan_Forbidden(t *testing.T) {
 
 func TestScan_NoBearer(t *testing.T) {
 	srv := newAdminSrv(t, &fakeRunner{startName: "manual-1"})
-	req := httptest.NewRequest(http.MethodPost, "/api/scan", nil)
 	w := httptest.NewRecorder()
-	srv.ServeHTTP(w, req)
+	srv.ServeHTTP(w, scanReq(""))
 	if w.Code != http.StatusForbidden {
 		t.Errorf("expected 403 when no bearer is supplied, got %d", w.Code)
+	}
+}
+
+func TestScan_CSRF(t *testing.T) {
+	srv := newAdminSrv(t, &fakeRunner{startName: "manual-1"})
+
+	cases := map[string]string{
+		"missing":    "",
+		"cross-site": "cross-site",
+		"same-site":  "same-site",
+		"none":       "none",
+	}
+	for name, site := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/scan", nil)
+			if site != "" {
+				req.Header.Set("Sec-Fetch-Site", site)
+			}
+			// Use a valid admin bearer so we know the rejection is from the
+			// CSRF gate and not from a missing identity.
+			req.Header.Set("Authorization", "Bearer admin")
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, req)
+			if w.Code != http.StatusForbidden {
+				t.Errorf("expected 403 for Sec-Fetch-Site=%q, got %d", site, w.Code)
+			}
+			if !strings.Contains(w.Body.String(), "cross-origin") {
+				t.Errorf("expected CSRF rejection body, got %q", w.Body.String())
+			}
+		})
 	}
 }
 
 func TestScan_Conflict(t *testing.T) {
 	runner := &fakeRunner{active: true, startName: "manual-1"}
 	srv := newAdminSrv(t, runner)
-	req := httptest.NewRequest(http.MethodPost, "/api/scan", nil)
-	req.Header.Set("Authorization", "Bearer admin")
 	w := httptest.NewRecorder()
-	srv.ServeHTTP(w, req)
+	srv.ServeHTTP(w, scanReq("admin"))
 	if w.Code != http.StatusConflict {
 		t.Errorf("expected 409 when a job is already active, got %d", w.Code)
 	}
@@ -250,10 +320,8 @@ func TestScan_Conflict(t *testing.T) {
 func TestScan_Success(t *testing.T) {
 	runner := &fakeRunner{startName: "manual-42"}
 	srv := newAdminSrv(t, runner)
-	req := httptest.NewRequest(http.MethodPost, "/api/scan", nil)
-	req.Header.Set("Authorization", "Bearer admin")
 	w := httptest.NewRecorder()
-	srv.ServeHTTP(w, req)
+	srv.ServeHTTP(w, scanReq("admin"))
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
 	}

--- a/internal/dashboard/scan_test.go
+++ b/internal/dashboard/scan_test.go
@@ -1,0 +1,270 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	testNamespace = "provenance-system"
+	testCronName  = "provenance-collector"
+)
+
+func makeCronJob() *batchv1.CronJob {
+	return &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testCronName,
+			Namespace: testNamespace,
+			UID:       types.UID("cj-uid-1"),
+		},
+		Spec: batchv1.CronJobSpec{
+			JobTemplate: batchv1.JobTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app.kubernetes.io/name": "provenance-collector"},
+				},
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							RestartPolicy: corev1.RestartPolicyOnFailure,
+							Containers: []corev1.Container{{
+								Name:  "collector",
+								Image: "test/collector:latest",
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestStartManualScan_CreatesJob(t *testing.T) {
+	client := fake.NewClientset(makeCronJob())
+	runner := NewK8sScanRunner(client, testNamespace, testCronName)
+
+	name, err := runner.StartManualScan(context.Background())
+	if err != nil {
+		t.Fatalf("StartManualScan: %v", err)
+	}
+
+	job, err := client.BatchV1().Jobs(testNamespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get created job: %v", err)
+	}
+	if job.Annotations["cronjob.kubernetes.io/instantiate"] != "manual" {
+		t.Errorf("missing/incorrect instantiate annotation: %v", job.Annotations)
+	}
+	if len(job.OwnerReferences) != 1 {
+		t.Fatalf("expected 1 owner reference, got %d", len(job.OwnerReferences))
+	}
+	owner := job.OwnerReferences[0]
+	if owner.Kind != "CronJob" || owner.Name != testCronName || owner.UID != "cj-uid-1" {
+		t.Errorf("unexpected owner reference: %+v", owner)
+	}
+	if len(job.Spec.Template.Spec.Containers) != 1 || job.Spec.Template.Spec.Containers[0].Image != "test/collector:latest" {
+		t.Errorf("job did not inherit CronJob template containers: %+v", job.Spec.Template.Spec.Containers)
+	}
+}
+
+func TestHasActiveManualJob(t *testing.T) {
+	yes := true
+	activeJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "manual-100",
+			Namespace: testNamespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "batch/v1", Kind: "CronJob", Name: testCronName, UID: "cj-uid-1",
+				Controller: &yes,
+			}},
+		},
+		Status: batchv1.JobStatus{Active: 1},
+	}
+	completedJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "manual-99",
+			Namespace: testNamespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "batch/v1", Kind: "CronJob", Name: testCronName, UID: "cj-uid-1",
+				Controller: &yes,
+			}},
+		},
+		Status: batchv1.JobStatus{Succeeded: 1, CompletionTime: &metav1.Time{}},
+	}
+
+	t.Run("active", func(t *testing.T) {
+		c := fake.NewClientset(makeCronJob(), activeJob)
+		runner := NewK8sScanRunner(c, testNamespace, testCronName)
+		got, err := runner.HasActiveManualJob(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !got {
+			t.Error("expected HasActiveManualJob=true with Active=1 job present")
+		}
+	})
+
+	t.Run("only completed", func(t *testing.T) {
+		c := fake.NewClientset(makeCronJob(), completedJob)
+		runner := NewK8sScanRunner(c, testNamespace, testCronName)
+		got, err := runner.HasActiveManualJob(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got {
+			t.Error("expected HasActiveManualJob=false when only completed job exists")
+		}
+	})
+
+	t.Run("ignores foreign cronjob", func(t *testing.T) {
+		foreign := activeJob.DeepCopy()
+		foreign.Name = "manual-other"
+		foreign.OwnerReferences[0].Name = "some-other-cronjob"
+		c := fake.NewClientset(makeCronJob(), foreign)
+		runner := NewK8sScanRunner(c, testNamespace, testCronName)
+		got, err := runner.HasActiveManualJob(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got {
+			t.Error("HasActiveManualJob should ignore jobs owned by a different CronJob")
+		}
+	})
+}
+
+// fakeRunner is a stub ScanRunner for HTTP-layer tests.
+type fakeRunner struct {
+	active    bool
+	activeErr error
+	startName string
+	startErr  error
+	starts    int
+}
+
+func (f *fakeRunner) HasActiveManualJob(context.Context) (bool, error) {
+	return f.active, f.activeErr
+}
+func (f *fakeRunner) StartManualScan(context.Context) (string, error) {
+	f.starts++
+	return f.startName, f.startErr
+}
+
+func newAdminSrv(t *testing.T, runner ScanRunner) *Server {
+	t.Helper()
+	stub := userInfoStub(t, map[string]string{
+		"admin": `{"sub":"u1","email":"a@x","groups":["/admins"]}`,
+		"user":  `{"sub":"u2","email":"u@x","groups":["/users"]}`,
+	}, nil)
+	t.Cleanup(stub.Close)
+	return NewServer(t.TempDir()).
+		WithAuth(AuthConfig{IssuerURL: stub.URL, AdminGroups: []string{"/admins"}}).
+		WithScanRunner(runner)
+}
+
+func TestScan_RequiresPOST(t *testing.T) {
+	srv := newAdminSrv(t, &fakeRunner{startName: "manual-1"})
+	req := httptest.NewRequest(http.MethodGet, "/api/scan", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestScan_AuthDisabled(t *testing.T) {
+	srv := NewServer(t.TempDir()) // no auth wired
+	req := httptest.NewRequest(http.MethodPost, "/api/scan", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 with no auth configured, got %d", w.Code)
+	}
+}
+
+func TestScan_NoRunner(t *testing.T) {
+	stub := userInfoStub(t, map[string]string{
+		"admin": `{"groups":["/admins"]}`,
+	}, nil)
+	defer stub.Close()
+	srv := NewServer(t.TempDir()).
+		WithAuth(AuthConfig{IssuerURL: stub.URL, AdminGroups: []string{"/admins"}})
+	// note: no WithScanRunner
+
+	req := httptest.NewRequest(http.MethodPost, "/api/scan", nil)
+	req.Header.Set("Authorization", "Bearer admin")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 with no runner wired, got %d", w.Code)
+	}
+}
+
+func TestScan_Forbidden(t *testing.T) {
+	runner := &fakeRunner{startName: "manual-1"}
+	srv := newAdminSrv(t, runner)
+	req := httptest.NewRequest(http.MethodPost, "/api/scan", nil)
+	req.Header.Set("Authorization", "Bearer user") // non-admin
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for non-admin, got %d", w.Code)
+	}
+	if runner.starts != 0 {
+		t.Errorf("non-admin must not trigger StartManualScan, got %d calls", runner.starts)
+	}
+}
+
+func TestScan_NoBearer(t *testing.T) {
+	srv := newAdminSrv(t, &fakeRunner{startName: "manual-1"})
+	req := httptest.NewRequest(http.MethodPost, "/api/scan", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 when no bearer is supplied, got %d", w.Code)
+	}
+}
+
+func TestScan_Conflict(t *testing.T) {
+	runner := &fakeRunner{active: true, startName: "manual-1"}
+	srv := newAdminSrv(t, runner)
+	req := httptest.NewRequest(http.MethodPost, "/api/scan", nil)
+	req.Header.Set("Authorization", "Bearer admin")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409 when a job is already active, got %d", w.Code)
+	}
+	if runner.starts != 0 {
+		t.Errorf("must not start a scan when one is already active; got %d starts", runner.starts)
+	}
+}
+
+func TestScan_Success(t *testing.T) {
+	runner := &fakeRunner{startName: "manual-42"}
+	srv := newAdminSrv(t, runner)
+	req := httptest.NewRequest(http.MethodPost, "/api/scan", nil)
+	req.Header.Set("Authorization", "Bearer admin")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp scanResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+	if resp.JobName != "manual-42" {
+		t.Errorf("expected jobName=manual-42, got %q", resp.JobName)
+	}
+	if runner.starts != 1 {
+		t.Errorf("expected exactly one StartManualScan call, got %d", runner.starts)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -15,18 +15,39 @@ import (
 // Server serves the provenance dashboard web UI.
 type Server struct {
 	reportsDir string
+	auth       *authenticator
+	scan       ScanRunner
 	mux        *http.ServeMux
 }
 
 // NewServer creates a dashboard HTTP handler that reads reports from reportsDir.
+// Authorization is disabled until WithAuth is called with a non-empty issuer.
+// The scan endpoint is disabled until WithScanRunner is called with a runner.
 func NewServer(reportsDir string) *Server {
 	s := &Server{reportsDir: reportsDir}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", s.handleIndex)
 	mux.HandleFunc("/api/reports", s.handleListReports)
 	mux.HandleFunc("/api/reports/", s.handleGetReport)
+	mux.HandleFunc("/api/me", s.handleMe)
+	mux.HandleFunc("/api/scan", s.handleScan)
 	mux.HandleFunc("/healthz", s.handleHealthz)
 	s.mux = mux
+	return s
+}
+
+// WithAuth attaches an OIDC authorization config. Passing a config with an
+// empty IssuerURL or AdminGroups leaves authorization disabled — /api/me
+// will still respond, but always with canRunScan=false.
+func (s *Server) WithAuth(cfg AuthConfig) *Server {
+	s.auth = newAuthenticator(cfg)
+	return s
+}
+
+// WithScanRunner attaches the runner used by /api/scan to create one-shot
+// Jobs. When unset, /api/scan responds with 503.
+func (s *Server) WithScanRunner(r ScanRunner) *Server {
+	s.scan = r
 	return s
 }
 
@@ -119,4 +140,26 @@ func (s *Server) loadReport(filename string) (*report.ProvenanceReport, error) {
 func (s *Server) handleIndex(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_, _ = w.Write([]byte(indexHTML))
+}
+
+// meResponse is the JSON shape returned by /api/me.
+type meResponse struct {
+	AuthEnabled bool     `json:"authEnabled"`
+	Email       string   `json:"email,omitempty"`
+	Groups      []string `json:"groups,omitempty"`
+	CanRunScan  bool     `json:"canRunScan"`
+}
+
+func (s *Server) handleMe(w http.ResponseWriter, r *http.Request) {
+	id := s.auth.identify(r.Context(), r)
+	resp := meResponse{
+		AuthEnabled: s.auth.enabled(),
+		CanRunScan:  s.auth.canRunScan(id),
+	}
+	if id != nil {
+		resp.Email = id.Email
+		resp.Groups = id.Groups
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
 }


### PR DESCRIPTION
## Summary

- Adds a "Run Scan" button to the dashboard that creates a one-shot Job from the chart's CronJob, replacing the wait-for-cron-or-kubectl workflow.
- Permission is decided server-side from the user's Keycloak `groups` claim via `<issuer>/userinfo`. The UI button is just a hint; `POST /api/scan` re-checks group membership before doing anything, and rejects cross-origin POSTs via a `Sec-Fetch-Site: same-origin` check (defense in depth against CSRF once the gateway injects the bearer from the session cookie).
- Surfaces `forwardAccessToken` on the NebariApp so the gateway injects `Authorization: Bearer <access_token>` upstream when the feature is enabled.

## Validated against a live cluster

Exercised end-to-end against a Nebari cluster running nebari-operator `v0.1.0-alpha.19`:

- An admin-group user sees the Run Scan button; non-admins do not.
- Clicking the button creates a `manual-<suffix>` Job with the `cronjob.kubernetes.io/instantiate=manual` annotation and a `CronJob` owner reference; the run completes and the new report appears on the timeline.
- `/api/me` returns the expected shape (`authEnabled`, `email`, `groups`, `canRunScan`), with the group decision based on exact match against the configured `adminGroups`.

Two infrastructure preconditions worth flagging for downstream operators:

- **nebari-operator ≥ `v0.1.0-alpha.18`** is required. Earlier versions' CRD does not include `forwardAccessToken`, so the API server silently strips the field from the rendered NebariApp; the resulting SecurityPolicy never forwards the bearer and `canRunScan` is always `false`.
- **`adminGroups` must match what the realm actually emits.** Confirm via `/api/me` before merging your values — on Nebari's default Keycloak group-membership mapper this is the bare group name (no leading `/`).

## How to enable

Off by default. Three values must be set together:

```yaml
webUI:
  enabled: true
  oidcIssuer: http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari
  adminGroups: ["<your-admin-group>"]   # match what `/api/me` returns
nebariapp:
  auth:
    forwardAccessToken: true
```

When any of `oidcIssuer` / `adminGroups` is unset, `/api/me` reports `canRunScan: false` and the button stays hidden. When the in-cluster Kubernetes client is unavailable, `/api/scan` returns 503 with a useful body instead of crashing.

## What's in the change

**Chart**
- `templates/role-web.yaml`, `templates/rolebinding-web.yaml` — namespace-scoped Role granting `create`/`get`/`list` on `batch/jobs` and `get` on `batch/cronjobs` to the dashboard SA.
- `templates/nebariapp.yaml` — passes `forwardAccessToken` through when set.
- `templates/deployment-web.yaml` — wires `PROVENANCE_NAMESPACE`, `PROVENANCE_CRONJOB_NAME`, and conditionally `PROVENANCE_OIDC_ISSUER` / `PROVENANCE_ADMIN_GROUPS`.

**Go (`internal/dashboard/`)**
- `auth.go` — bearer extraction, Keycloak `/userinfo` lookup, 60s in-memory cache keyed by SHA-256 of the token, group-claim normalizer for array/string/null shapes. Doc comment on `fetchUserInfo` calls out that `IssuerURL` is "where the pod sends userinfo requests" and does **not** need to equal the token's `iss` claim — split-horizon DNS friendly.
- `scan.go`:
  - `ScanRunner` interface + client-go-backed impl. Clones the CronJob's `spec.jobTemplate` into a Job with `GenerateName: "manual-"` so the apiserver picks a unique suffix (no TOCTOU collision on rapid double-clicks).
  - `HasActiveManualJob` reads `Status.Conditions` for `Complete` / `Failed` instead of inspecting Active/Succeeded/Failed counters, which all read zero in the window between the last pod being collected and the controller writing the terminal condition (and, post-Kubernetes 1.28, `CompletionTime` is only set on success).
  - `handleScan` gates on `Sec-Fetch-Site: same-origin` before any auth/runner check (CSRF defense), then re-checks the group claim, then 409s if a manual job is already in flight, then creates the Job.
- `server.go` — registers `/api/me` and `/api/scan` always; `WithAuth` / `WithScanRunner` are opt-in builders.
- `index.go` — `initAuth()` hides the button until `/api/me` returns `canRunScan: true`; `runScan()` POSTs `/api/scan`, toasts the result, and polls `/api/reports` for up to 5 min to detect the new report and refresh the UI.

`cmd/dashboard/main.go` — wires env → `AuthConfig` and (when `PROVENANCE_NAMESPACE` and `PROVENANCE_CRONJOB_NAME` are set) builds an in-cluster clientset; failures degrade to 503, not crash.

## Test plan

- [x] `go test ./...` passes locally and in CI.
- [x] `helm template chart` with defaults: no `PROVENANCE_OIDC_ISSUER` / `PROVENANCE_ADMIN_GROUPS` env vars on the web pod; Role/RoleBinding not rendered when `webUI.enabled=false`.
- [x] `helm template chart --set webUI.enabled=true --set webUI.oidcIssuer=... --set 'webUI.adminGroups={admin}' --set nebariapp.auth.forwardAccessToken=true`: all three env vars present, Role/RoleBinding rendered, NebariApp has `forwardAccessToken: true`.
- [x] Live cluster validation (see "Validated against a live cluster" above).
- [x] Unit tests cover: `Sec-Fetch-Site` rejection for `cross-site` / `same-site` / `none` / missing; 409 when a manual job is already active; identity-based 403 for non-admin users; `jobDone` recognises both `Complete` and `Failed` terminal conditions (regression guard for the heuristic the previous revision used).