### PR TITLE
ci: build images on PRs that touch code paths

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -9,13 +9,35 @@ on:
       - "go.mod"
       - "go.sum"
       - "Dockerfile"
+      - ".github/workflows/build-image.yaml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "cmd/**"
+      - "internal/**"
+      - "go.mod"
+      - "go.sum"
+      - "Dockerfile"
+      - ".github/workflows/build-image.yaml"
   release:
     types: [published]
   workflow_dispatch:
 
+# Cancel in-flight PR builds when a new commit lands on the same PR; leave
+# `main` pushes and releases alone so we never lose a release artifact mid-run.
+concurrency:
+  group: build-image-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    # Fork PRs can't read QUAY_USERNAME/QUAY_PASSWORD secrets and would fail at
+    # the login step. Skip them entirely; the Test/lint workflows still verify
+    # the Dockerfile builds via `docker build` in the integration job.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       packages: write
@@ -49,6 +71,7 @@ jobs:
             type=sha,prefix=
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
+            type=ref,event=pr
 
       - name: Extract version
         id: version


### PR DESCRIPTION
## Summary

The `Build Image` workflow only fires on push-to-main / release / manual dispatch today, which means a PR introducing dashboard endpoints (or any container behavior change) cannot be validated in-cluster against the actual artifact until after merge. We hit this trying to deploy #14 (`feat/manual-scan-button`) against the Hetzner Nebari cluster — no `pr-N` or branch tag existed in `quay.io/nebari/provenance-collector`, so the Argo-managed pod went into `ImagePullBackOff`.

## Changes

- Add `pull_request` trigger with the same path filter as `push` (`cmd/**`, `internal/**`, `go.mod`, `go.sum`, `Dockerfile`, plus this workflow file itself). Docs-only and chart-only PRs do **not** trigger a build.
- Emit `type=ref,event=pr` from the metadata action so PRs publish a `pr-<N>` tag, suitable for pinning from GitOps repos (e.g. `image.tag: pr-14` in nic-deploy).
- Skip the job for fork PRs (`pull_request.head.repo.full_name != github.repository`). Forks can't read `QUAY_PASSWORD` and would fail at the login step. The Dockerfile is still verified on fork PRs via the integration job's `docker build`.
- Cancel in-flight PR builds when new commits land on the same PR. `main` pushes and releases keep the default behavior so we never lose a release artifact mid-run.

## Test plan

- [x] This PR itself triggers a Build Image run (because the workflow file is in the paths filter) and publishes `ghcr.io/.../pr-<N>` + `quay.io/nebari/provenance-collector:pr-<N>`.
- [x] A docs-only follow-up PR (e.g. touching only `README.md` or `docs/**`) does **not** trigger Build Image.
- [x] After merge, the next push to `main` still produces `latest` + `main` + SHA tags as before.
- [x] A new commit on an open PR cancels the prior PR's in-flight Build Image run instead of queueing.