### PR TITLE
chore(dashboard): auto-cleanup manual scan Jobs after 1h

### DIFF
--- a/chart/templates/deployment-web.yaml
+++ b/chart/templates/deployment-web.yaml
@@ -57,6 +57,12 @@ spec:
             - name: PROVENANCE_ADMIN_GROUPS
               value: {{ join "," . | quote }}
             {{- end }}
+            # Always emitted: "0" disables the TTL (Job persists after
+            # completion) and `with` would treat the YAML zero-value as
+            # falsy and drop the env var, which the Go side reads as
+            # "unset → use default".
+            - name: PROVENANCE_MANUAL_JOB_TTL
+              value: {{ .Values.webUI.manualJobTTL | quote }}
           ports:
             - name: http
               containerPort: {{ .Values.webUI.port }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -89,6 +89,12 @@ webUI:
   # exact and case-sensitive; use the same form Keycloak returns in the token
   # (typically with a leading "/").
   adminGroups: []
+  # How long a finished manual scan Job lingers before the TTLAfterFinished
+  # controller deletes it. Manual Jobs aren't tracked by the CronJob's
+  # successfulJobsHistoryLimit, so without a TTL they would accumulate. Use
+  # any Go duration string ("1h", "30m", "24h"). Set to "0" to disable the
+  # TTL and keep manual Jobs around for debugging.
+  manualJobTTL: "1h"
 
 # =============================================================================
 # Persistence (PVC for report storage)

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -39,11 +39,14 @@ func main() {
 		AdminGroups: splitAndTrim(os.Getenv("PROVENANCE_ADMIN_GROUPS")),
 	}
 
+	manualJobTTL := parseManualJobTTL(os.Getenv("PROVENANCE_MANUAL_JOB_TTL"))
+
 	slog.Info("configuration loaded",
 		"addr", addr,
 		"reportsDir", reportsDir,
 		"authIssuer", authCfg.IssuerURL,
 		"adminGroups", len(authCfg.AdminGroups),
+		"manualJobTTL", manualJobTTL.String(),
 	)
 
 	srv := dashboard.NewServer(reportsDir).WithAuth(authCfg)
@@ -54,7 +57,7 @@ func main() {
 	namespace := os.Getenv("PROVENANCE_NAMESPACE")
 	cronJobName := os.Getenv("PROVENANCE_CRONJOB_NAME")
 	if namespace != "" && cronJobName != "" {
-		if runner, err := buildScanRunner(namespace, cronJobName); err != nil {
+		if runner, err := buildScanRunner(namespace, cronJobName, manualJobTTL); err != nil {
 			slog.Warn("scan endpoint disabled: kubernetes client unavailable",
 				"namespace", namespace, "cronJob", cronJobName, "error", err)
 		} else {
@@ -93,7 +96,7 @@ func main() {
 	}
 }
 
-func buildScanRunner(namespace, cronJobName string) (dashboard.ScanRunner, error) {
+func buildScanRunner(namespace, cronJobName string, manualJobTTL time.Duration) (dashboard.ScanRunner, error) {
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, err
@@ -102,7 +105,26 @@ func buildScanRunner(namespace, cronJobName string) (dashboard.ScanRunner, error
 	if err != nil {
 		return nil, err
 	}
-	return dashboard.NewK8sScanRunner(client, namespace, cronJobName), nil
+	return dashboard.NewK8sScanRunner(client, namespace, cronJobName, manualJobTTL), nil
+}
+
+// parseManualJobTTL reads the PROVENANCE_MANUAL_JOB_TTL env var.
+// Empty / unparseable values fall back to DefaultManualJobTTL.
+// Set the value to "0" (or any zero-duration string) to disable the TTL
+// entirely so manual Jobs persist until manually deleted.
+func parseManualJobTTL(v string) time.Duration {
+	if v == "" {
+		return dashboard.DefaultManualJobTTL
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		slog.Warn("invalid PROVENANCE_MANUAL_JOB_TTL, using default", "value", v, "error", err)
+		return dashboard.DefaultManualJobTTL
+	}
+	if d < 0 {
+		return 0
+	}
+	return d
 }
 
 func splitAndTrim(s string) []string {

--- a/internal/dashboard/scan.go
+++ b/internal/dashboard/scan.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -23,18 +24,34 @@ type ScanRunner interface {
 	StartManualScan(ctx context.Context) (string, error)
 }
 
+// DefaultManualJobTTL is the fallback TTL applied to manual Jobs when no
+// explicit value is configured. The report itself is the durable artifact
+// (stored on the dashboard's PVC with its own retention); the Job object
+// only needs to live long enough for an operator to inspect pod logs after
+// a failure.
+const DefaultManualJobTTL = time.Hour
+
 // k8sScanRunner is the production ScanRunner: it talks to a real apiserver
 // via client-go to inspect and create Jobs from a specific CronJob.
 type k8sScanRunner struct {
-	client    kubernetes.Interface
-	namespace string
-	cronJob   string
+	client       kubernetes.Interface
+	namespace    string
+	cronJob      string
+	manualJobTTL time.Duration // 0 disables TTL on manual Jobs entirely
 }
 
 // NewK8sScanRunner builds a ScanRunner backed by the provided clientset.
 // Exported so cmd/dashboard can wire it from an in-cluster config.
-func NewK8sScanRunner(client kubernetes.Interface, namespace, cronJob string) ScanRunner {
-	return &k8sScanRunner{client: client, namespace: namespace, cronJob: cronJob}
+// manualJobTTL controls Spec.TTLSecondsAfterFinished on created Jobs;
+// pass 0 to skip setting the field (Job persists until namespace teardown
+// or manual deletion).
+func NewK8sScanRunner(client kubernetes.Interface, namespace, cronJob string, manualJobTTL time.Duration) ScanRunner {
+	return &k8sScanRunner{
+		client:       client,
+		namespace:    namespace,
+		cronJob:      cronJob,
+		manualJobTTL: manualJobTTL,
+	}
 }
 
 func (k *k8sScanRunner) HasActiveManualJob(ctx context.Context) (bool, error) {
@@ -77,6 +94,15 @@ func (k *k8sScanRunner) StartManualScan(ctx context.Context) (string, error) {
 		return "", err
 	}
 	yes := true
+	spec := cj.Spec.JobTemplate.Spec
+	// Scheduled runs are pruned by successfulJobsHistoryLimit, but manual
+	// runs aren't tracked there and would otherwise pile up indefinitely.
+	// Override whatever TTL the CronJob's jobTemplate may carry (operators
+	// who want the Jobs to stick around can set manualJobTTL=0).
+	if k.manualJobTTL > 0 {
+		ttl := int32(k.manualJobTTL.Seconds())
+		spec.TTLSecondsAfterFinished = &ttl
+	}
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			// GenerateName lets the apiserver pick a unique suffix so two
@@ -98,7 +124,7 @@ func (k *k8sScanRunner) StartManualScan(ctx context.Context) (string, error) {
 				BlockOwnerDeletion: &yes,
 			}},
 		},
-		Spec: cj.Spec.JobTemplate.Spec,
+		Spec: spec,
 	}
 	created, err := k.client.BatchV1().Jobs(k.namespace).Create(ctx, job, metav1.CreateOptions{})
 	if err != nil {

--- a/internal/dashboard/scan_test.go
+++ b/internal/dashboard/scan_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -27,8 +28,9 @@ func scanReq(bearer string) *http.Request {
 }
 
 const (
-	testNamespace = "provenance-system"
-	testCronName  = "provenance-collector"
+	testNamespace    = "provenance-system"
+	testCronName     = "provenance-collector"
+	testManualJobTTL = 90 * time.Minute // distinct from DefaultManualJobTTL so tests fail loudly on a regression
 )
 
 func makeCronJob() *batchv1.CronJob {
@@ -61,7 +63,7 @@ func makeCronJob() *batchv1.CronJob {
 
 func TestStartManualScan_CreatesJob(t *testing.T) {
 	client := fake.NewClientset(makeCronJob())
-	runner := NewK8sScanRunner(client, testNamespace, testCronName)
+	runner := NewK8sScanRunner(client, testNamespace, testCronName, testManualJobTTL)
 
 	name, err := runner.StartManualScan(context.Background())
 	if err != nil {
@@ -84,6 +86,29 @@ func TestStartManualScan_CreatesJob(t *testing.T) {
 	}
 	if len(job.Spec.Template.Spec.Containers) != 1 || job.Spec.Template.Spec.Containers[0].Image != "test/collector:latest" {
 		t.Errorf("job did not inherit CronJob template containers: %+v", job.Spec.Template.Spec.Containers)
+	}
+	if job.Spec.TTLSecondsAfterFinished == nil {
+		t.Fatal("expected TTLSecondsAfterFinished to be set on a manual Job")
+	}
+	if got := *job.Spec.TTLSecondsAfterFinished; got != int32(testManualJobTTL.Seconds()) {
+		t.Errorf("expected TTLSecondsAfterFinished=%d, got %d", int32(testManualJobTTL.Seconds()), got)
+	}
+}
+
+func TestStartManualScan_TTLDisabled(t *testing.T) {
+	client := fake.NewClientset(makeCronJob())
+	runner := NewK8sScanRunner(client, testNamespace, testCronName, 0) // 0 = no TTL
+
+	name, err := runner.StartManualScan(context.Background())
+	if err != nil {
+		t.Fatalf("StartManualScan: %v", err)
+	}
+	job, err := client.BatchV1().Jobs(testNamespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get created job: %v", err)
+	}
+	if job.Spec.TTLSecondsAfterFinished != nil {
+		t.Errorf("expected TTLSecondsAfterFinished to be unset when manualJobTTL=0, got %d", *job.Spec.TTLSecondsAfterFinished)
 	}
 }
 
@@ -138,7 +163,7 @@ func TestHasActiveManualJob(t *testing.T) {
 
 	t.Run("active", func(t *testing.T) {
 		c := fake.NewClientset(makeCronJob(), activeJob)
-		runner := NewK8sScanRunner(c, testNamespace, testCronName)
+		runner := NewK8sScanRunner(c, testNamespace, testCronName, testManualJobTTL)
 		got, err := runner.HasActiveManualJob(context.Background())
 		if err != nil {
 			t.Fatal(err)
@@ -150,7 +175,7 @@ func TestHasActiveManualJob(t *testing.T) {
 
 	t.Run("only completed", func(t *testing.T) {
 		c := fake.NewClientset(makeCronJob(), completedJob)
-		runner := NewK8sScanRunner(c, testNamespace, testCronName)
+		runner := NewK8sScanRunner(c, testNamespace, testCronName, testManualJobTTL)
 		got, err := runner.HasActiveManualJob(context.Background())
 		if err != nil {
 			t.Fatal(err)
@@ -162,7 +187,7 @@ func TestHasActiveManualJob(t *testing.T) {
 
 	t.Run("only failed", func(t *testing.T) {
 		c := fake.NewClientset(makeCronJob(), failedJob)
-		runner := NewK8sScanRunner(c, testNamespace, testCronName)
+		runner := NewK8sScanRunner(c, testNamespace, testCronName, testManualJobTTL)
 		got, err := runner.HasActiveManualJob(context.Background())
 		if err != nil {
 			t.Fatal(err)
@@ -177,7 +202,7 @@ func TestHasActiveManualJob(t *testing.T) {
 		foreign.Name = "manual-other"
 		foreign.OwnerReferences[0].Name = "some-other-cronjob"
 		c := fake.NewClientset(makeCronJob(), foreign)
-		runner := NewK8sScanRunner(c, testNamespace, testCronName)
+		runner := NewK8sScanRunner(c, testNamespace, testCronName, testManualJobTTL)
 		got, err := runner.HasActiveManualJob(context.Background())
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
## Summary

Sets `Spec.TTLSecondsAfterFinished` on the one-shot Jobs that `/api/scan` (the Run Scan button) creates, so the in-tree `TTLAfterFinished` controller deletes each finished manual Job after a configurable delay. Default is 1h; operator can override via `webUI.manualJobTTL`, or set it to `"0"` to keep Jobs around for debugging.

## Why

`CronJob.successfulJobsHistoryLimit: 3` / `failedJobsHistoryLimit: 3` is implemented by the CronJob controller and only prunes Jobs the controller scheduled itself. Manual Jobs (the ones the dashboard creates with `GenerateName: "manual-"`, mirroring what `kubectl create job --from=cronjob/…` does) have the CronJob as owner ref but are **not** tracked in its scheduling history, so the history-limit cleanup ignores them and they accumulate indefinitely.

1h is enough time for an operator to `kubectl logs` a failed pod if something went wrong; the actual report is the durable artifact and lives on the dashboard's PVC under the existing `reportRetention` policy.

## Configuration

```yaml
webUI:
  manualJobTTL: "1h"   # default
```

- Any Go duration string (`"1h"`, `"30m"`, `"24h"`, `"7d"`).
- `"0"` disables the TTL entirely — Jobs will sit around until manually deleted or the namespace tears down.
- Empty / unparseable values fall back to `dashboard.DefaultManualJobTTL` (1h).

## What changed

**Go**
- `internal/dashboard/scan.go` — `NewK8sScanRunner` takes a `time.Duration`; the runner only sets `Spec.TTLSecondsAfterFinished` when the duration is > 0. Exported `DefaultManualJobTTL` for callers that want to honour the default explicitly.
- `cmd/dashboard/main.go` — reads `PROVENANCE_MANUAL_JOB_TTL`, parses with fallback, passes to the runner. Logged at startup.

**Chart**
- `chart/values.yaml` — new `webUI.manualJobTTL: "1h"`.
- `chart/templates/deployment-web.yaml` — always emits `PROVENANCE_MANUAL_JOB_TTL` (gated only on `webUI.enabled` which already wraps the block). The env var is intentionally unconditional inside the env list because Helm's `with` treats numeric zero as falsy, which would silently drop the "disable TTL" case if we used `{{- with .Values.webUI.manualJobTTL }}`.

## Test plan

- [x] `go test ./internal/dashboard/...` — two new assertions: TTL is set to the configured duration; TTL field is `nil` when `manualJobTTL=0`.
- [x] `helm template` renders correctly for `"1h"` (default), `"4h"` (override), and `"0"` (disabled) — all three emit the env var with the literal value.
- [ ] Live: trigger a manual scan, wait an hour, confirm the `manual-*` Job and its pod are gone while the report stays on the dashboard.

## Notes

- Doesn't affect scheduled runs from the CronJob — those are still pruned by `successfulJobsHistoryLimit` and friends, as before. If we ever want scheduled runs to use TTL too, that's a chart-only change to the CronJob's `jobTemplate.spec.ttlSecondsAfterFinished` and doesn't need code.