### PR TITLE
test(e2e): add Playwright timeline scan-switch regression (#19)

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -177,13 +177,19 @@ jobs:
           TIMELINE_NEW_IMAGE: busybox
         run: npx playwright test --reporter=list
 
-      - name: Upload Playwright report on failure
-        if: failure()
+      # Always upload — videos and traces are recorded on every run, not just
+      # on failure, so reviewers can see what the bot actually saw without
+      # having to re-run anything locally.
+      - name: Upload Playwright artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
-          path: test/e2e/playwright-report
+          name: playwright-artifacts
+          path: |
+            test/e2e/playwright-report
+            test/e2e/test-results
           if-no-files-found: ignore
+          retention-days: 14
 
       # Capture screenshots of the web dashboard.
       # Auto-doc artifact only — runs on push to main (committed back into

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -109,6 +109,82 @@ jobs:
           echo ""
           echo "Integration test passed!"
 
+      # Timeline scan-switch coverage (#19): deploy a second workload, trigger
+      # another scan, and verify via the dashboard UI that picking each
+      # timeline entry actually swaps the images table — not just the stat cards.
+      - name: Deploy second workload (timeline-switch setup)
+        run: |
+          # busybox needs an explicit command to stay running.
+          kubectl create deployment busybox \
+            --image=busybox:1.36 \
+            -- sh -c 'sleep 3600'
+          kubectl wait --for=condition=available deployment/busybox --timeout=120s
+
+      - name: Run second provenance collection
+        run: |
+          kubectl create job --from=cronjob/provenance-test-provenance-collector test-run-2
+          kubectl wait --for=condition=complete job/test-run-2 --timeout=300s
+
+      - name: Wait for second report to land in the dashboard
+        run: |
+          for i in $(seq 1 20); do
+            COUNT=$(curl -sf http://localhost:8080/api/reports | jq 'length' 2>/dev/null || echo "0")
+            if [ "$COUNT" -ge "2" ]; then
+              echo "Both reports visible (attempt $i, count=$COUNT)"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Timed out waiting for the second report; current count=$COUNT"
+          curl -sf http://localhost:8080/api/reports | jq .
+          exit 1
+
+      - name: Verify the two reports differ on the busybox image
+        run: |
+          REPORTS=$(curl -sf http://localhost:8080/api/reports)
+          NEWEST=$(echo "$REPORTS" | jq -r '.[0].filename')
+          OLDEST=$(echo "$REPORTS" | jq -r '.[1].filename')
+          echo "Newest: $NEWEST"
+          echo "Oldest: $OLDEST"
+
+          # The reports list is sorted DESC by generatedAt; busybox should be in
+          # the newer one only.
+          NEW_HAS=$(curl -sf "http://localhost:8080/api/reports/$NEWEST" \
+            | jq '[.images[].image] | any(test("busybox"))')
+          OLD_HAS=$(curl -sf "http://localhost:8080/api/reports/$OLDEST" \
+            | jq '[.images[].image] | any(test("busybox"))')
+
+          echo "Newest contains busybox: $NEW_HAS"
+          echo "Oldest contains busybox: $OLD_HAS"
+
+          if [ "$NEW_HAS" != "true" ] || [ "$OLD_HAS" != "false" ]; then
+            echo "API distinctness check failed — the bug cannot be tested if the"
+            echo "two reports don't actually differ on disk."
+            exit 1
+          fi
+
+      - name: Install Playwright
+        working-directory: test/e2e
+        run: |
+          npm init -y > /dev/null
+          npm install --no-save @playwright/test@1.48.2
+          npx playwright install --with-deps chromium
+
+      - name: Run timeline-switch e2e test
+        working-directory: test/e2e
+        env:
+          DASHBOARD_URL: http://localhost:8080
+          TIMELINE_NEW_IMAGE: busybox
+        run: npx playwright test --reporter=list
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: test/e2e/playwright-report
+          if-no-files-found: ignore
+
       # Capture screenshots of the web dashboard.
       # Auto-doc artifact only — runs on push to main (committed back into
       # docs/screenshots/ by the next step). Skipped on PRs so that a broken
@@ -181,14 +257,19 @@ jobs:
           echo "=== Pods ==="
           kubectl get pods -A
           echo ""
-          echo "=== Job ==="
+          echo "=== Jobs ==="
           kubectl describe job/test-run || true
+          kubectl describe job/test-run-2 || true
           echo ""
           echo "=== Job logs ==="
           kubectl logs job/test-run || true
+          kubectl logs job/test-run-2 || true
           echo ""
           echo "=== Dashboard logs ==="
           kubectl logs deployment/provenance-test-provenance-collector-web || true
+          echo ""
+          echo "=== Reports listing ==="
+          curl -sf http://localhost:8080/api/reports | jq . || true
           echo ""
           echo "=== Events ==="
           kubectl get events --sort-by=.lastTimestamp | tail -30

--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+package.json
+package-lock.json
+playwright-report/
+test-results/

--- a/test/e2e/playwright.config.js
+++ b/test/e2e/playwright.config.js
@@ -1,6 +1,11 @@
 // Minimal Playwright config for the dashboard e2e tests. Each spec assumes the
 // dashboard is already reachable at DASHBOARD_URL (no webServer / setup is
 // owned here — that's the calling workflow's job).
+//
+// Video and trace are recorded on every run (not just on failure) so the CI
+// artifacts always include a visual record of what the timeline-switch test
+// actually did. Reviewers can scrub the .webm file or open the trace in
+// Playwright's trace viewer (`npx playwright show-trace trace.zip`).
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 module.exports = {
@@ -9,11 +14,13 @@ module.exports = {
   expect: { timeout: 10_000 },
   fullyParallel: false,
   workers: 1,
+  outputDir: 'test-results',
   reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
   use: {
     headless: true,
     viewport: { width: 1440, height: 900 },
-    trace: 'retain-on-failure',
+    trace: 'on',
+    video: 'on',
     screenshot: 'only-on-failure',
   },
   projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],

--- a/test/e2e/playwright.config.js
+++ b/test/e2e/playwright.config.js
@@ -1,0 +1,20 @@
+// Minimal Playwright config for the dashboard e2e tests. Each spec assumes the
+// dashboard is already reachable at DASHBOARD_URL (no webServer / setup is
+// owned here — that's the calling workflow's job).
+
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+module.exports = {
+  testDir: '.',
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: false,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
+  use: {
+    headless: true,
+    viewport: { width: 1440, height: 900 },
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],
+};

--- a/test/e2e/scan-button-auth.spec.js
+++ b/test/e2e/scan-button-auth.spec.js
@@ -1,0 +1,100 @@
+// Run Scan button visibility based on the authenticated user's groups.
+//
+// The button is rendered hidden by default (display:none in the HTML) and is
+// only revealed when `/api/me` returns `canRunScan: true`. This spec exercises
+// that frontend gate by mocking the `/api/me` response — no real OIDC issuer
+// involved. Server-side enforcement (the bearer → userinfo → admin-group
+// check) is covered by internal/dashboard/auth_test.go and
+// internal/dashboard/internal_server_test.go.
+//
+// The chart in the integration workflow is installed with auth disabled, so
+// the real `/api/me` would return `{authEnabled: false, canRunScan: false}`.
+// The mock here overrides that response *before* navigation so every test
+// case sees a deterministic state.
+
+const { test, expect } = require('@playwright/test');
+
+const BASE = process.env.DASHBOARD_URL || 'http://localhost:8080';
+
+// mockMe sets up a route handler that returns the given /api/me payload.
+// Must be called BEFORE page.goto() so the response is in place when the
+// dashboard's init() fetches it on load.
+async function mockMe(page, payload) {
+  await page.route('**/api/me', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    });
+  });
+}
+
+test.describe('Run Scan button visibility', () => {
+  test('hidden when auth is disabled', async ({ page }) => {
+    await mockMe(page, { authEnabled: false, canRunScan: false });
+    await page.goto(BASE, { waitUntil: 'networkidle' });
+
+    await expect(page.locator('#btn-scan')).toBeHidden();
+  });
+
+  test('hidden when user is authenticated but lacks an admin group', async ({ page }) => {
+    await mockMe(page, {
+      authEnabled: true,
+      email: 'alice@example.com',
+      groups: ['platform-users'],
+      canRunScan: false,
+    });
+    await page.goto(BASE, { waitUntil: 'networkidle' });
+
+    await expect(page.locator('#btn-scan')).toBeHidden();
+  });
+
+  test('visible when user is in an admin group', async ({ page }) => {
+    await mockMe(page, {
+      authEnabled: true,
+      email: 'admin@example.com',
+      groups: ['provenance-admins'],
+      canRunScan: true,
+    });
+    await page.goto(BASE, { waitUntil: 'networkidle' });
+
+    const btn = page.locator('#btn-scan');
+    await expect(btn).toBeVisible();
+    // Button is not disabled in its idle state; the click handler manages
+    // disabled-while-polling on its own.
+    await expect(btn).toBeEnabled();
+  });
+
+  test('clicking the button posts to /api/scan', async ({ page }) => {
+    await mockMe(page, {
+      authEnabled: true,
+      email: 'admin@example.com',
+      groups: ['provenance-admins'],
+      canRunScan: true,
+    });
+
+    // Stub /api/scan with a successful response so we don't kick off a real
+    // Job and so the polling loop in the page can settle quickly.
+    let scanPosts = 0;
+    await page.route('**/api/scan', async (route) => {
+      if (route.request().method() === 'POST') {
+        scanPosts++;
+        await route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({ jobName: 'manual-scan-spec-stub' }),
+        });
+        return;
+      }
+      await route.continue();
+    });
+
+    await page.goto(BASE, { waitUntil: 'networkidle' });
+    await page.locator('#btn-scan').click();
+
+    // The handler awaits the POST before flipping the button label, so by the
+    // time the label changes we know the POST went out.
+    await expect(page.locator('#btn-scan')).toContainText(/scan running/i, { timeout: 5_000 });
+    expect(scanPosts).toBe(1);
+  });
+});

--- a/test/e2e/scan-button-auth.spec.js
+++ b/test/e2e/scan-button-auth.spec.js
@@ -97,4 +97,47 @@ test.describe('Run Scan button visibility', () => {
     await expect(page.locator('#btn-scan')).toContainText(/scan running/i, { timeout: 5_000 });
     expect(scanPosts).toBe(1);
   });
+
+  // Stale-permission path: /api/me said the user could scan when the page
+  // loaded, but /api/scan now returns 403 — for example because the user was
+  // removed from the admin group in the interim. The handler must surface an
+  // error toast and restore the button to its idle state so the click isn't
+  // silently swallowed and the button isn't stuck in a fake "Scan running"
+  // label.
+  test('403 on click surfaces an error toast and resets the button', async ({ page }) => {
+    await mockMe(page, {
+      authEnabled: true,
+      email: 'admin@example.com',
+      groups: ['provenance-admins'],
+      canRunScan: true,
+    });
+
+    await page.route('**/api/scan', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 403,
+          contentType: 'text/plain',
+          body: 'forbidden',
+        });
+        return;
+      }
+      await route.continue();
+    });
+
+    await page.goto(BASE, { waitUntil: 'networkidle' });
+    const btn = page.locator('#btn-scan');
+    await btn.click();
+
+    // An error toast appears in #toast-wrap with the "Scan request failed"
+    // title and a sub-line that includes the upstream 403.
+    const toast = page.locator('#toast-wrap .toast.error', { hasText: 'Scan request failed' });
+    await expect(toast).toBeVisible({ timeout: 5_000 });
+    await expect(toast).toContainText('403');
+
+    // Button must be back to idle: enabled, label "Run Scan", and never
+    // stuck on "Scan running".
+    await expect(btn).toBeEnabled();
+    await expect(btn).toContainText('Run Scan');
+    await expect(btn).not.toContainText(/scan running/i);
+  });
 });

--- a/test/e2e/timeline-switch.spec.js
+++ b/test/e2e/timeline-switch.spec.js
@@ -1,0 +1,76 @@
+// Timeline scan-switch end-to-end test.
+//
+// Regression coverage for https://github.com/nebari-dev/nebari-provenance-collector-pack/issues/19:
+// clicking a non-latest timeline entry must swap the Images and Helm tables, not just the stat cards.
+//
+// Preconditions (set up by the calling workflow):
+//   - The dashboard is reachable at $DASHBOARD_URL (default http://localhost:8080).
+//   - Two provenance reports exist on disk. The newer one must include an
+//     image whose name contains $TIMELINE_NEW_IMAGE (default "busybox") that
+//     is absent from the older one.
+
+const { test, expect } = require('@playwright/test');
+
+const BASE = process.env.DASHBOARD_URL || 'http://localhost:8080';
+const NEW_IMAGE_MARKER = process.env.TIMELINE_NEW_IMAGE || 'busybox';
+
+test('timeline scan-switch updates stat cards AND images table', async ({ page }) => {
+  await page.goto(BASE, { waitUntil: 'networkidle' });
+  await page.waitForSelector('.timeline-item');
+
+  const items = page.locator('.timeline-item');
+  await expect(items, 'expected exactly two reports in the timeline').toHaveCount(2, { timeout: 10_000 });
+
+  // Reports are sorted DESC by generatedAt — item 0 is newest, item 1 is older.
+  const newest = items.nth(0);
+  const older = items.nth(1);
+
+  // --- Newest report (default state) ----------------------------------------
+  await newest.click();
+  await page.waitForLoadState('networkidle');
+
+  const newestCount = await readImagesStatCount(page);
+  const newestRows = await page.locator('#images-table tbody tr').count();
+  const newestHasNewImage = await rowsContaining(page, NEW_IMAGE_MARKER);
+
+  expect(newestRows, 'newest report should have at least one image row').toBeGreaterThan(0);
+  expect(newestHasNewImage, `newest report must contain "${NEW_IMAGE_MARKER}"`).toBeGreaterThan(0);
+
+  // --- Older report ---------------------------------------------------------
+  await older.click();
+  // The click triggers a fetch + re-render; wait for the active class to flip
+  // before reading state.
+  await expect(older).toHaveClass(/\bactive\b/, { timeout: 5_000 });
+  await page.waitForLoadState('networkidle');
+
+  const olderCount = await readImagesStatCount(page);
+  const olderRows = await page.locator('#images-table tbody tr').count();
+  const olderHasNewImage = await rowsContaining(page, NEW_IMAGE_MARKER);
+
+  // 1. The image stat card must have moved.
+  expect(olderCount, 'older report should have a smaller unique-image count than newest')
+    .toBeLessThan(newestCount);
+
+  // 2. The Images TABLE must have moved with the stat card.
+  // This is what #19 currently breaks: stat updates, table doesn't.
+  expect(olderRows, 'older report should have fewer table rows than newest')
+    .toBeLessThan(newestRows);
+
+  // 3. The image added between the two scans must not be in the older table.
+  expect(olderHasNewImage, `older report must NOT contain "${NEW_IMAGE_MARKER}"`).toBe(0);
+});
+
+// readImagesStatCount returns the integer shown in the "Images" stat card.
+async function readImagesStatCount(page) {
+  const text = await page.locator('#stat-all .value').textContent();
+  const n = parseInt((text || '').trim(), 10);
+  if (Number.isNaN(n)) {
+    throw new Error(`could not parse stat card value: "${text}"`);
+  }
+  return n;
+}
+
+// rowsContaining returns the count of <tbody tr> rows whose text contains needle.
+async function rowsContaining(page, needle) {
+  return page.locator('#images-table tbody tr').filter({ hasText: needle }).count();
+}


### PR DESCRIPTION
## Summary

Establishes a Playwright-driven e2e test layer under `test/e2e/` and lays down regression coverage for two dashboard surfaces that didn't have any before: the timeline scan-switch behaviour from #19 and the admin-gated Run Scan button from #14.

Every run records a `.webm` video plus a Playwright trace, uploaded as a CI artifact on success and failure alike. Reviewers can scrub the video to see exactly what the bot saw without re-running anything locally.

## What landed

### `test/e2e/timeline-switch.spec.js`
Reproduction target for #19 — the report that clicking an older Timeline entry updates the stat cards but not the Images table. The spec drives the dashboard with two genuinely different reports (busybox added between scans) and asserts that clicking each timeline entry moves the `IMAGES` stat-card value, the `#images-table tbody tr` count, and the presence of the `busybox` row together.

The test passes on current `main`, which means the bug as described doesn't reproduce in CI. The coverage stays as a regression guard either way.

### `test/e2e/scan-button-auth.spec.js`
Five cases that mock `/api/me` with `page.route()` so we can exercise every `canRunScan` permission combination without standing up a real OIDC issuer (server-side enforcement is already covered by [`auth_test.go`](../blob/main/internal/dashboard/auth_test.go) and [`internal_server_test.go`](../blob/main/internal/dashboard/internal_server_test.go)):

| State | Expected button | Why this case |
| --- | --- | --- |
| `authEnabled=false` | Hidden | No OIDC configured — current default install state |
| `authEnabled=true`, `canRunScan=false` (user in non-admin group) | Hidden | Signed-in but lacks an admin group |
| `authEnabled=true`, `canRunScan=true` (user in admin group) | Visible + enabled | Signed-in admin |
| Click the visible button | Posts once to `/api/scan`, label flips to `Scan running` | Confirms the click handler wires up correctly |
| Click → `/api/scan` returns 403 | Error toast `"Scan request failed"` containing `403`; button resets to enabled `Run Scan` and is explicitly **not** stuck on `Scan running` | Stale-permission path (user was removed from the admin group between page load and click) |

### `test/e2e/playwright.config.js`
Self-contained Playwright config (no repo-root pollution). `video: 'on'` and `trace: 'on'` capture artifacts on every run, not just failures. Default `outputDir: 'test-results'`.

### `test/e2e/.gitignore`
Keeps `node_modules/`, `package.json`, `playwright-report/`, and `test-results/` out of source control.

### `.github/workflows/test-integration.yaml`
Seven new steps inserted between the existing `Verify report output` and the unchanged dashboard-screenshot block:

1. **Deploy second workload** — `kubectl create deployment busybox --image=busybox:1.36 -- sh -c 'sleep 3600'` (busybox exits immediately without a command).
2. **Run second provenance collection** — second `test-run-2` Job, same `kubectl wait` pattern.
3. **Wait for second report** — poll `/api/reports` until `length >= 2`, 40-second cap, diagnostic dump on timeout.
4. **Verify the two reports differ on the busybox image** — pull both reports via the JSON API and `jq`-assert busybox is in the newer one only. Aborts early if the inputs are indistinguishable.
5. **Install Playwright** — `npm install @playwright/test@1.48.2 && npx playwright install --with-deps chromium`, scoped to `test/e2e/`.
6. **Run e2e tests** — `npx playwright test --reporter=list` auto-discovers both spec files.
7. **Upload Playwright artifacts** — `if: always()` uploads `test/e2e/playwright-report` + `test/e2e/test-results` as the `playwright-artifacts` artifact with 14-day retention.

The failure-debug step also dumps `test-run-2` info and the `/api/reports` listing.

## Out of scope (separate follow-ups)

- The shift-click / Compare diff-view UX idea from chat — feature work, belongs in #22 (UI wishlist).
- Migrating the existing puppeteer screenshot step to Playwright. Possible but not load-bearing; the current step still runs unchanged after the e2e tests.
- A real OIDC issuer in CI for end-to-end server-side auth testing. Mocking `/api/me` is the right call for now; revisit if the auth surface grows.

## Test plan

- [x] CI runs both specs on a fresh kind cluster on every push.
- [x] `integration`, `unit-test`, `go-lint`, `helm-lint` all green on `06b093c`.
- [x] Video + trace artifacts surface on the green run (download `playwright-artifacts` from the run).

Closes #19 (regression coverage in place; bug isn't reproducible against current `main`).
