### PR TITLE
chore: add pack-metadata.yaml for the software-pack dashboard

### DIFF
--- a/pack-metadata.yaml
+++ b/pack-metadata.yaml
@@ -1,0 +1,24 @@
+# pack-metadata.yaml
+#
+# Consumed by the Nebari pack dashboard
+# (https://github.com/nebari-dev/software-pack-dashboard), which fetches this
+# file once per hour to render the dashboard row for this pack.
+#
+# Schema:
+#   https://github.com/nebari-dev/software-pack-dashboard/blob/main/schema/pack-metadata.schema.json
+#
+# Validate locally before committing:
+#   pip install check-jsonschema
+#   check-jsonschema --schemafile <path-to>/pack-metadata.schema.json pack-metadata.yaml
+
+name: nebari-provenance-collector-pack
+display_name: Provenance Collector
+description: Kubernetes-native CronJob plus web dashboard that audits running images and Helm releases for digests, signatures, SLSA/SBOM attestations, and registry updates.
+level: alpha
+owner: viniciusdc
+deprecated: false
+product_owner: null
+
+nebariapp_integration: full
+scope:
+  standalone-supported: yes


### PR DESCRIPTION
## Summary

Adds the top-level `pack-metadata.yaml` that [`nebari-dev/software-pack-dashboard`](https://github.com/nebari-dev/software-pack-dashboard) reads to render this pack's row on the dashboard. Currently the row carries a 🆘 `metadata-missing` flag and shows `–` for the Level / Owner / NebariApp / Standalone columns; merging this fills those in.

Validated against the upstream schema with `check-jsonschema` before pushing.

## Values

| Field | Value | Why |
|---|---|---|
| `name` | `nebari-provenance-collector-pack` | Must match the repo name exactly (schema requirement). |
| `display_name` | `Provenance Collector` | Same name the chart already uses on the NebariApp landing page. |
| `description` | Kubernetes-native CronJob plus web dashboard that audits running images and Helm releases for digests, signatures, SLSA/SBOM attestations, and registry updates. | ≤ 200 chars; covers the dashboard angle the README already led with. |
| `level` | `alpha` | Matches the current `v0.1.0-alpha.*` tag stream. |
| `owner` | `viniciusdc` | Most active maintainer on the default branch. |
| `deprecated` | `false` | – |
| `product_owner` | `null` | Optional below `ga`. |
| `nebariapp_integration` | `full` | The chart provisions a `NebariApp` CR out of the box (`nebariapp.enabled=true` mode), including OIDC, routing, and the landing-page card. |
| `scope.standalone-supported` | `yes` | The chart installs cleanly with `nebariapp.enabled=false` against any Kubernetes cluster, no nebari-operator required. |

## Test plan

- [x] `check-jsonschema --schemafile schema/pack-metadata.schema.json pack-metadata.yaml` → `ok -- validation done`.
- [ ] After merge, wait for the next `Refresh pack dashboard` workflow run on the dashboard repo and confirm the `metadata-missing` flag drops off this pack's row and the Level / Owner / NebariApp / Standalone columns populate.