### PR TITLE
feat(dashboard): export reports as CSV or Markdown

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -162,7 +162,7 @@ jobs:
           npm install --no-save @playwright/test@1.48.2
           npx playwright install --with-deps chromium
 
-      - name: Run timeline-switch e2e test
+      - name: Run dashboard e2e tests
         working-directory: test/e2e
         env:
           DASHBOARD_URL: http://localhost:8080

--- a/internal/dashboard/export.go
+++ b/internal/dashboard/export.go
@@ -1,0 +1,194 @@
+package dashboard
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/nebari-dev/provenance-collector/internal/report"
+)
+
+// handleExport returns the selected report rendered as CSV or Markdown.
+// Query parameters:
+//
+//	format=csv|markdown|md (default csv)
+//	filename=<timestamped json> (default provenance-latest.json)
+//
+// The filename param lets the dashboard export whichever report the user is
+// currently viewing in the timeline, not just the latest. Path traversal is
+// rejected with the same rules as /api/reports/{filename}.
+func (s *Server) handleExport(w http.ResponseWriter, r *http.Request) {
+	format := r.URL.Query().Get("format")
+	if format == "" {
+		format = "csv"
+	}
+
+	filename := r.URL.Query().Get("filename")
+	if filename == "" {
+		filename = "provenance-latest.json"
+	} else if strings.Contains(filename, "/") || strings.Contains(filename, "..") {
+		http.Error(w, "invalid filename", http.StatusBadRequest)
+		return
+	}
+
+	rpt, err := s.loadReport(filename)
+	if err != nil {
+		http.Error(w, "report not found", http.StatusNotFound)
+		return
+	}
+
+	switch format {
+	case "csv":
+		s.exportCSV(w, rpt)
+	case "markdown", "md":
+		s.exportMarkdown(w, rpt)
+	default:
+		http.Error(w, "unsupported format: use csv or markdown", http.StatusBadRequest)
+	}
+}
+
+func (s *Server) exportCSV(w http.ResponseWriter, rpt *report.ProvenanceReport) {
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("Content-Disposition", "attachment; filename=provenance-report.csv")
+
+	var b strings.Builder
+	b.WriteString("Image,Namespace,Workload Kind,Workload Name,Digest,Signed,Verified,SLSA Provenance,SBOM,SBOM Format,Update Available,Current Tag,Latest In Major\n")
+
+	for _, img := range rpt.Images {
+		signed, verified := "false", "false"
+		if img.Signature != nil {
+			signed = fmt.Sprintf("%t", img.Signature.Signed)
+			verified = fmt.Sprintf("%t", img.Signature.Verified)
+		}
+
+		slsa := "false"
+		if img.Provenance != nil {
+			slsa = fmt.Sprintf("%t", img.Provenance.HasProvenance)
+		}
+
+		sbom, sbomFmt := "false", ""
+		if img.SBOM != nil {
+			sbom = fmt.Sprintf("%t", img.SBOM.HasSBOM)
+			sbomFmt = img.SBOM.Format
+		}
+
+		updateAvail, currentTag, latestInMajor := "false", "", ""
+		if img.Update != nil {
+			updateAvail = fmt.Sprintf("%t", img.Update.UpdateAvailable)
+			currentTag = img.Update.CurrentTag
+			latestInMajor = img.Update.LatestInMajor
+		}
+
+		fmt.Fprintf(&b, "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n",
+			csvEscape(img.Image),
+			csvEscape(img.Namespace),
+			csvEscape(img.Workload.Kind),
+			csvEscape(img.Workload.Name),
+			csvEscape(img.Digest),
+			signed, verified, slsa, sbom,
+			csvEscape(sbomFmt),
+			updateAvail,
+			csvEscape(currentTag),
+			csvEscape(latestInMajor),
+		)
+	}
+
+	_, _ = w.Write([]byte(b.String()))
+}
+
+func (s *Server) exportMarkdown(w http.ResponseWriter, rpt *report.ProvenanceReport) {
+	w.Header().Set("Content-Type", "text/markdown")
+	w.Header().Set("Content-Disposition", "attachment; filename=provenance-report.md")
+
+	var b strings.Builder
+
+	b.WriteString("# Provenance Report\n\n")
+	fmt.Fprintf(&b, "**Generated:** %s\n\n", rpt.Metadata.GeneratedAt.Format("2006-01-02 15:04:05 UTC"))
+	if rpt.Metadata.ClusterName != "" {
+		fmt.Fprintf(&b, "**Cluster:** %s\n\n", rpt.Metadata.ClusterName)
+	}
+	fmt.Fprintf(&b, "**Namespaces:** %s\n\n", strings.Join(rpt.Metadata.NamespacesScanned, ", "))
+
+	s2 := rpt.Summary
+	b.WriteString("## Summary\n\n")
+	b.WriteString("| Metric | Count |\n|---|---|\n")
+	fmt.Fprintf(&b, "| Unique Images | %d |\n", s2.UniqueImages)
+	fmt.Fprintf(&b, "| Signed | %d |\n", s2.SignedImages)
+	fmt.Fprintf(&b, "| Verified | %d |\n", s2.VerifiedImages)
+	fmt.Fprintf(&b, "| SLSA Provenance | %d |\n", s2.ImagesWithProvenance)
+	fmt.Fprintf(&b, "| With SBOM | %d |\n", s2.ImagesWithSBOM)
+	fmt.Fprintf(&b, "| Updates Available | %d |\n", s2.ImagesWithUpdates)
+	fmt.Fprintf(&b, "| Helm Releases | %d |\n", s2.TotalHelmReleases)
+	b.WriteString("\n")
+
+	b.WriteString("## Container Images\n\n")
+	b.WriteString("| Image | Namespace | Workload | Signed | SLSA | SBOM | Update |\n")
+	b.WriteString("|---|---|---|---|---|---|---|\n")
+
+	for _, img := range rpt.Images {
+		signed := "-"
+		if img.Signature != nil {
+			switch {
+			case img.Signature.Verified:
+				signed = "Verified"
+			case img.Signature.Signed:
+				signed = "Signed"
+			default:
+				signed = "No"
+			}
+		}
+
+		slsa := "-"
+		if img.Provenance != nil {
+			if img.Provenance.HasProvenance {
+				slsa = "Yes"
+			} else {
+				slsa = "No"
+			}
+		}
+
+		sbom := "-"
+		if img.SBOM != nil {
+			if img.SBOM.HasSBOM {
+				sbom = strings.ToUpper(img.SBOM.Format)
+			} else {
+				sbom = "No"
+			}
+		}
+
+		update := "-"
+		if img.Update != nil {
+			if img.Update.UpdateAvailable {
+				update = img.Update.LatestInMajor
+				if update == "" {
+					update = img.Update.NewestAvailable
+				}
+			} else {
+				update = "Current"
+			}
+		}
+
+		workload := fmt.Sprintf("%s/%s", img.Workload.Kind, img.Workload.Name)
+		fmt.Fprintf(&b, "| `%s` | %s | %s | %s | %s | %s | %s |\n",
+			img.Image, img.Namespace, workload, signed, slsa, sbom, update)
+	}
+
+	if len(rpt.HelmReleases) > 0 {
+		b.WriteString("\n## Helm Releases\n\n")
+		b.WriteString("| Release | Namespace | Chart | Version | App Version | Status |\n")
+		b.WriteString("|---|---|---|---|---|---|\n")
+		for _, hr := range rpt.HelmReleases {
+			fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s |\n",
+				hr.ReleaseName, hr.Namespace, hr.Chart, hr.Version, hr.AppVersion, hr.Status)
+		}
+	}
+
+	_, _ = w.Write([]byte(b.String()))
+}
+
+func csvEscape(s string) string {
+	if strings.ContainsAny(s, ",\"\n") {
+		return "\"" + strings.ReplaceAll(s, "\"", "\"\"") + "\""
+	}
+	return s
+}

--- a/internal/dashboard/export_test.go
+++ b/internal/dashboard/export_test.go
@@ -1,0 +1,194 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestExportCSV(t *testing.T) {
+	dir := setupTestDir(t)
+	srv := NewServer(dir)
+
+	req := httptest.NewRequest("GET", "/api/export?format=csv", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/csv" {
+		t.Errorf("expected text/csv, got %s", ct)
+	}
+	if cd := w.Header().Get("Content-Disposition"); !strings.Contains(cd, "provenance-report.csv") {
+		t.Errorf("expected csv filename in Content-Disposition, got %s", cd)
+	}
+
+	body := w.Body.String()
+	lines := strings.Split(strings.TrimSpace(body), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected at least header + 1 row, got %d lines", len(lines))
+	}
+	if !strings.HasPrefix(lines[0], "Image,Namespace,") {
+		t.Errorf("unexpected CSV header: %s", lines[0])
+	}
+	if !strings.Contains(lines[1], "nginx:1.27") {
+		t.Errorf("expected nginx:1.27 in CSV data, got: %s", lines[1])
+	}
+}
+
+func TestExportMarkdown(t *testing.T) {
+	dir := setupTestDir(t)
+	srv := NewServer(dir)
+
+	req := httptest.NewRequest("GET", "/api/export?format=markdown", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/markdown" {
+		t.Errorf("expected text/markdown, got %s", ct)
+	}
+
+	body := w.Body.String()
+	for _, want := range []string{
+		"# Provenance Report",
+		"## Summary",
+		"## Container Images",
+		"nginx:1.27",
+		"## Helm Releases",
+		"ingress-nginx",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected markdown to contain %q", want)
+		}
+	}
+}
+
+func TestExportMdShorthand(t *testing.T) {
+	dir := setupTestDir(t)
+	srv := NewServer(dir)
+
+	req := httptest.NewRequest("GET", "/api/export?format=md", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/markdown" {
+		t.Errorf("expected text/markdown, got %s", ct)
+	}
+}
+
+func TestExportDefaultFormat(t *testing.T) {
+	dir := setupTestDir(t)
+	srv := NewServer(dir)
+
+	req := httptest.NewRequest("GET", "/api/export", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/csv" {
+		t.Errorf("expected default format csv, got %s", ct)
+	}
+}
+
+func TestExportUnsupportedFormat(t *testing.T) {
+	dir := setupTestDir(t)
+	srv := NewServer(dir)
+
+	req := httptest.NewRequest("GET", "/api/export?format=pdf", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for unsupported format, got %d", w.Code)
+	}
+}
+
+func TestExportNoReport(t *testing.T) {
+	srv := NewServer(t.TempDir())
+
+	req := httptest.NewRequest("GET", "/api/export?format=csv", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 when no report exists, got %d", w.Code)
+	}
+}
+
+// TestExportFilenameParam exercises the ?filename= override so the dashboard's
+// timeline selection can drive the export. setupTestDir writes
+// provenance-20250615-060000.json with the same content as the latest, so a
+// successful response confirms the parameter was honored (without it the
+// endpoint would still return the latest, which would look identical here).
+func TestExportFilenameParam(t *testing.T) {
+	dir := setupTestDir(t)
+	srv := NewServer(dir)
+
+	req := httptest.NewRequest("GET", "/api/export?format=csv&filename=provenance-20250615-060000.json", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "nginx:1.27") {
+		t.Error("expected timestamped-file export to contain the same fixture image")
+	}
+}
+
+func TestExportFilenameNotFound(t *testing.T) {
+	dir := setupTestDir(t)
+	srv := NewServer(dir)
+
+	req := httptest.NewRequest("GET", "/api/export?format=csv&filename=does-not-exist.json", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for missing filename, got %d", w.Code)
+	}
+}
+
+func TestExportFilenamePathTraversal(t *testing.T) {
+	dir := setupTestDir(t)
+	srv := NewServer(dir)
+
+	for _, bad := range []string{"../etc/passwd", "subdir/file.json", ".."} {
+		req := httptest.NewRequest("GET", "/api/export?format=csv&filename="+bad, nil)
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("filename=%q: expected 400, got %d", bad, w.Code)
+		}
+	}
+}
+
+func TestCSVEscape(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"simple", "simple"},
+		{"has,comma", "\"has,comma\""},
+		{"has\"quote", "\"has\"\"quote\""},
+		{"has\nnewline", "\"has\nnewline\""},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		got := csvEscape(tc.input)
+		if got != tc.want {
+			t.Errorf("csvEscape(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}

--- a/internal/dashboard/index.go
+++ b/internal/dashboard/index.go
@@ -149,10 +149,16 @@ const indexHTML = `<!DOCTYPE html>
   .btn-scan .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--purple); box-shadow: 0 0 6px rgba(167,139,250,0.6); }
   .btn-scan:hover:not(:disabled) .dot { background: white; box-shadow: 0 0 6px rgba(255,255,255,0.6); }
 
-  /* Export buttons */
-  .export-group { display: flex; gap: 4px; }
-  .export-btn { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 4px 10px; color: var(--muted); font-size: 11px; font-family: var(--font); cursor: pointer; transition: all 0.15s ease; text-decoration: none; display: inline-flex; align-items: center; gap: 4px; }
-  .export-btn:hover { border-color: var(--purple-dark); color: var(--text); }
+  /* Export menu */
+  .export-menu { position: relative; display: inline-flex; }
+  .export-btn { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 4px 10px; color: var(--muted); font-size: 11px; font-family: var(--font); cursor: pointer; transition: all 0.15s ease; text-decoration: none; display: inline-flex; align-items: center; gap: 5px; }
+  .export-btn:hover, .export-btn[aria-expanded="true"] { border-color: var(--purple-dark); color: var(--text); }
+  .export-btn .caret { font-size: 9px; transition: transform 0.15s ease; }
+  .export-btn[aria-expanded="true"] .caret { transform: rotate(180deg); }
+  .export-popover { position: absolute; top: calc(100% + 4px); right: 0; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 4px; min-width: 140px; box-shadow: 0 4px 16px rgba(0,0,0,0.4); z-index: 150; display: flex; flex-direction: column; gap: 2px; }
+  .export-popover[hidden] { display: none; }
+  .export-item { padding: 6px 10px; font-size: 12px; color: var(--text-secondary); border-radius: 4px; text-decoration: none; cursor: pointer; transition: background 0.1s ease; }
+  .export-item:hover, .export-item:focus { background: var(--surface-2); color: var(--text); outline: none; }
 
   /* Toast */
   .toast-wrap { position: fixed; bottom: 20px; right: 20px; z-index: 300; display: flex; flex-direction: column; gap: 8px; max-width: 420px; }
@@ -184,10 +190,15 @@ const indexHTML = `<!DOCTYPE html>
     <div class="nav-meta">
       <span id="cluster-name"></span>
       <span id="last-updated"></span>
-      <div class="export-group">
-        <a id="export-csv" class="export-btn" href="/api/export?format=csv" download title="Download the selected report as CSV">CSV</a>
-        <a id="export-md" class="export-btn" href="/api/export?format=markdown" download title="Download the selected report as Markdown">MD</a>
-        <a id="export-json" class="export-btn" href="/api/reports/latest" download="provenance-report.json" title="Download the selected report as JSON">JSON</a>
+      <div class="export-menu">
+        <button id="export-toggle" class="export-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="export-popover" onclick="toggleExportMenu()" title="Download the selected report">
+          <span>Export</span><span class="caret">&#9662;</span>
+        </button>
+        <div id="export-popover" class="export-popover" role="menu" hidden>
+          <a id="export-csv" class="export-item" role="menuitem" href="/api/export?format=csv" download>CSV</a>
+          <a id="export-md" class="export-item" role="menuitem" href="/api/export?format=markdown" download>Markdown</a>
+          <a id="export-json" class="export-item" role="menuitem" href="/api/reports/latest" download="provenance-report.json">JSON</a>
+        </div>
       </div>
       <button id="btn-scan" class="btn-scan" style="display:none" onclick="runScan()" title="Trigger a manual provenance scan">
         <span class="dot"></span><span>Run Scan</span>
@@ -383,8 +394,8 @@ async function loadReport(filename) {
   document.getElementById('cluster-name').textContent = currentReport.metadata.clusterName || '';
 }
 
-// updateExportLinks repoints the nav-bar Export buttons at whichever report is
-// currently being viewed. Without this, the CSV / MD / JSON buttons would
+// updateExportLinks repoints the Export menu items at whichever report is
+// currently being viewed. Without this, the CSV / MD / JSON entries would
 // always export the latest report regardless of the timeline selection.
 function updateExportLinks(filename) {
   const enc = encodeURIComponent(filename);
@@ -395,6 +406,43 @@ function updateExportLinks(filename) {
   if (md) md.href = '/api/export?format=markdown&filename=' + enc;
   if (json) json.href = '/api/reports/' + enc;
 }
+
+// toggleExportMenu opens / closes the Export dropdown. Closing is also wired
+// to outside-clicks and Escape (see the listeners below).
+function toggleExportMenu() {
+  const btn = document.getElementById('export-toggle');
+  const menu = document.getElementById('export-popover');
+  if (!btn || !menu) return;
+  const open = btn.getAttribute('aria-expanded') === 'true';
+  setExportMenuOpen(!open);
+}
+
+function setExportMenuOpen(open) {
+  const btn = document.getElementById('export-toggle');
+  const menu = document.getElementById('export-popover');
+  if (!btn || !menu) return;
+  btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+  if (open) {
+    menu.removeAttribute('hidden');
+  } else {
+    menu.setAttribute('hidden', '');
+  }
+}
+
+document.addEventListener('click', (ev) => {
+  const wrap = document.querySelector('.export-menu');
+  if (wrap && !wrap.contains(ev.target)) setExportMenuOpen(false);
+  // Clicking an item should close the popover after the browser starts the
+  // download. The role=menuitem anchors live inside .export-menu so the
+  // outside-click branch above doesn't fire; close explicitly here.
+  if (ev.target && ev.target.classList && ev.target.classList.contains('export-item')) {
+    setExportMenuOpen(false);
+  }
+});
+
+document.addEventListener('keydown', (ev) => {
+  if (ev.key === 'Escape') setExportMenuOpen(false);
+});
 
 function resetFilters() {
   imageFilters = { search: '', namespace: '', signature: '', sbom: '', provenance: '', update: '' };

--- a/internal/dashboard/index.go
+++ b/internal/dashboard/index.go
@@ -149,6 +149,11 @@ const indexHTML = `<!DOCTYPE html>
   .btn-scan .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--purple); box-shadow: 0 0 6px rgba(167,139,250,0.6); }
   .btn-scan:hover:not(:disabled) .dot { background: white; box-shadow: 0 0 6px rgba(255,255,255,0.6); }
 
+  /* Export buttons */
+  .export-group { display: flex; gap: 4px; }
+  .export-btn { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 4px 10px; color: var(--muted); font-size: 11px; font-family: var(--font); cursor: pointer; transition: all 0.15s ease; text-decoration: none; display: inline-flex; align-items: center; gap: 4px; }
+  .export-btn:hover { border-color: var(--purple-dark); color: var(--text); }
+
   /* Toast */
   .toast-wrap { position: fixed; bottom: 20px; right: 20px; z-index: 300; display: flex; flex-direction: column; gap: 8px; max-width: 420px; }
   .toast { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--purple); border-radius: var(--radius-sm); padding: 10px 14px; font-size: 12px; color: var(--text); box-shadow: 0 4px 12px rgba(0,0,0,0.4); animation: slidein 0.2s ease; }
@@ -179,6 +184,11 @@ const indexHTML = `<!DOCTYPE html>
     <div class="nav-meta">
       <span id="cluster-name"></span>
       <span id="last-updated"></span>
+      <div class="export-group">
+        <a id="export-csv" class="export-btn" href="/api/export?format=csv" download title="Download the selected report as CSV">CSV</a>
+        <a id="export-md" class="export-btn" href="/api/export?format=markdown" download title="Download the selected report as Markdown">MD</a>
+        <a id="export-json" class="export-btn" href="/api/reports/latest" download="provenance-report.json" title="Download the selected report as JSON">JSON</a>
+      </div>
       <button id="btn-scan" class="btn-scan" style="display:none" onclick="runScan()" title="Trigger a manual provenance scan">
         <span class="dot"></span><span>Run Scan</span>
       </button>
@@ -367,9 +377,23 @@ async function loadReport(filename) {
   renderFilters(currentReport);
   renderImages(currentReport);
   renderHelm(currentReport);
+  updateExportLinks(filename);
   const d = new Date(currentReport.metadata.generatedAt);
   document.getElementById('last-updated').textContent = d.toLocaleString();
   document.getElementById('cluster-name').textContent = currentReport.metadata.clusterName || '';
+}
+
+// updateExportLinks repoints the nav-bar Export buttons at whichever report is
+// currently being viewed. Without this, the CSV / MD / JSON buttons would
+// always export the latest report regardless of the timeline selection.
+function updateExportLinks(filename) {
+  const enc = encodeURIComponent(filename);
+  const csv = document.getElementById('export-csv');
+  const md = document.getElementById('export-md');
+  const json = document.getElementById('export-json');
+  if (csv) csv.href = '/api/export?format=csv&filename=' + enc;
+  if (md) md.href = '/api/export?format=markdown&filename=' + enc;
+  if (json) json.href = '/api/reports/' + enc;
 }
 
 function resetFilters() {

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -31,6 +31,7 @@ func NewServer(reportsDir string) *Server {
 	mux.HandleFunc("/api/reports/", s.handleGetReport)
 	mux.HandleFunc("/api/me", s.handleMe)
 	mux.HandleFunc("/api/scan", s.handleScan)
+	mux.HandleFunc("/api/export", s.handleExport)
 	mux.HandleFunc("/healthz", s.handleHealthz)
 	s.mux = mux
 	return s

--- a/test/e2e/export-download.spec.js
+++ b/test/e2e/export-download.spec.js
@@ -87,22 +87,21 @@ test.describe('Export menu', () => {
     expect(md).toContain('## Container Images');
 
     // One row per image under "## Container Images". Find the table that
-    // follows the heading and count the data rows (skip header + separator).
+    // follows the heading and count the data rows. Skip the header row
+    // (contains "| Image |") and the separator row (matches /^\|[-:|\s]+$/,
+    // i.e. only pipes / dashes / colons / whitespace — covers both `|---|`
+    // and `| --- |` styles).
     const imgSection = md.split('## Container Images')[1];
     expect(imgSection, 'Container Images section must exist').toBeTruthy();
     const imgTable = imgSection.split('## ')[0]; // stop at the next H2 if any
-    const imgDataRows = imgTable
-      .split('\n')
-      .filter((l) => l.startsWith('|') && !l.startsWith('| ---') && !l.includes('| Image |'));
+    const imgDataRows = markdownDataRows(imgTable, '| Image |');
     expect(imgDataRows.length, 'one Markdown image row per image in the source report')
       .toBe(truth.images.length);
 
     if (truth.helmReleases && truth.helmReleases.length > 0) {
       expect(md).toContain('## Helm Releases');
       const helmSection = md.split('## Helm Releases')[1];
-      const helmRows = helmSection
-        .split('\n')
-        .filter((l) => l.startsWith('|') && !l.startsWith('| ---') && !l.includes('| Release |'));
+      const helmRows = markdownDataRows(helmSection, '| Release |');
       expect(helmRows.length, 'one Markdown helm row per release in the source report')
         .toBe(truth.helmReleases.length);
     }
@@ -145,4 +144,15 @@ function csvField(s) {
     return '"' + s.replace(/"/g, '""') + '"';
   }
   return s;
+}
+
+// markdownDataRows returns the data rows of a Markdown table from a section
+// blob, skipping the header (matched by headerNeedle) and the separator row
+// (any line consisting only of pipes, dashes, colons, and whitespace).
+function markdownDataRows(section, headerNeedle) {
+  return section
+    .split('\n')
+    .filter((l) => l.startsWith('|'))
+    .filter((l) => !l.includes(headerNeedle))
+    .filter((l) => !/^\|[-:|\s]+$/.test(l));
 }

--- a/test/e2e/export-download.spec.js
+++ b/test/e2e/export-download.spec.js
@@ -1,0 +1,148 @@
+// Export menu download-validation test.
+//
+// Drives the dashboard's Export dropdown for each format (CSV, Markdown, JSON),
+// captures the actual download event, and shape-validates the file against the
+// dashboard's own JSON API (the source of truth — the export endpoints render
+// from the same on-disk report).
+//
+// Preconditions (set up by the calling workflow):
+//   - The dashboard is reachable at $DASHBOARD_URL (default http://localhost:8080).
+//   - At least one provenance report exists on disk.
+
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+
+const BASE = process.env.DASHBOARD_URL || 'http://localhost:8080';
+
+test.describe('Export menu', () => {
+  let truth;
+  let truthFilename;
+
+  test.beforeAll(async ({ request }) => {
+    // Source of truth: the API response for the latest report. The Export
+    // endpoints render from the same file, so any disagreement is a bug in
+    // the renderer.
+    const list = await request.get(`${BASE}/api/reports`);
+    expect(list.ok(), 'GET /api/reports must succeed').toBeTruthy();
+    const reports = await list.json();
+    expect(reports.length, 'expected at least one report').toBeGreaterThan(0);
+    truthFilename = reports[0].filename;
+    const latest = await request.get(`${BASE}/api/reports/${truthFilename}`);
+    expect(latest.ok(), 'GET /api/reports/<latest> must succeed').toBeTruthy();
+    truth = await latest.json();
+  });
+
+  test('Export menu toggles open and closed', async ({ page }) => {
+    await page.goto(BASE, { waitUntil: 'networkidle' });
+
+    const toggle = page.locator('#export-toggle');
+    const menu = page.locator('#export-popover');
+
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(menu).toBeHidden();
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(menu).toBeVisible();
+
+    // Escape closes.
+    await page.keyboard.press('Escape');
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(menu).toBeHidden();
+
+    // Re-open, then click outside to close.
+    await toggle.click();
+    await expect(menu).toBeVisible();
+    await page.locator('#stats').click();
+    await expect(menu).toBeHidden();
+  });
+
+  test('CSV download has the expected header and one row per image', async ({ page }) => {
+    const csv = await openMenuAndDownload(page, '#export-csv');
+
+    const lines = csv.split('\n').filter((l) => l.length > 0);
+    const header = lines[0];
+    const dataRows = lines.slice(1);
+
+    expect(header, 'CSV header must lead with the expected schema columns')
+      .toBe('Image,Namespace,Workload Kind,Workload Name,Digest,Signed,Verified,SLSA Provenance,SBOM,SBOM Format,Update Available,Current Tag,Latest In Major');
+
+    expect(dataRows.length, 'one CSV row per image in the source report')
+      .toBe(truth.images.length);
+
+    // Every truth image should appear on exactly one row. Match on the image
+    // field (first column) — that's the only one guaranteed unique enough to
+    // not collide on a kind cluster with multiple replicasets.
+    for (const img of truth.images) {
+      const found = dataRows.some((row) => row.startsWith(csvField(img.image) + ','));
+      expect(found, `CSV must contain a row for ${img.image}`).toBeTruthy();
+    }
+  });
+
+  test('Markdown download has the expected sections', async ({ page }) => {
+    const md = await openMenuAndDownload(page, '#export-md');
+
+    expect(md).toContain('# Provenance Report');
+    expect(md).toContain('## Summary');
+    expect(md).toContain('## Container Images');
+
+    // One row per image under "## Container Images". Find the table that
+    // follows the heading and count the data rows (skip header + separator).
+    const imgSection = md.split('## Container Images')[1];
+    expect(imgSection, 'Container Images section must exist').toBeTruthy();
+    const imgTable = imgSection.split('## ')[0]; // stop at the next H2 if any
+    const imgDataRows = imgTable
+      .split('\n')
+      .filter((l) => l.startsWith('|') && !l.startsWith('| ---') && !l.includes('| Image |'));
+    expect(imgDataRows.length, 'one Markdown image row per image in the source report')
+      .toBe(truth.images.length);
+
+    if (truth.helmReleases && truth.helmReleases.length > 0) {
+      expect(md).toContain('## Helm Releases');
+      const helmSection = md.split('## Helm Releases')[1];
+      const helmRows = helmSection
+        .split('\n')
+        .filter((l) => l.startsWith('|') && !l.startsWith('| ---') && !l.includes('| Release |'));
+      expect(helmRows.length, 'one Markdown helm row per release in the source report')
+        .toBe(truth.helmReleases.length);
+    }
+  });
+
+  test('JSON download matches the API response byte-shape', async ({ page }) => {
+    const raw = await openMenuAndDownload(page, '#export-json');
+    const parsed = JSON.parse(raw);
+
+    // The JSON download is just a passthrough of /api/reports/<filename>, so
+    // top-level shape and image / helm counts must match the truth exactly.
+    expect(parsed.metadata.generatedAt).toBe(truth.metadata.generatedAt);
+    expect(parsed.summary.uniqueImages).toBe(truth.summary.uniqueImages);
+    expect(parsed.summary.totalImages).toBe(truth.summary.totalImages);
+    expect(parsed.images.length).toBe(truth.images.length);
+    expect((parsed.helmReleases || []).length).toBe((truth.helmReleases || []).length);
+  });
+});
+
+// openMenuAndDownload opens the Export menu, clicks the given menu-item
+// selector, captures the download event, and returns the file contents as a
+// UTF-8 string.
+async function openMenuAndDownload(page, itemSelector) {
+  await page.goto(BASE, { waitUntil: 'networkidle' });
+  await page.locator('#export-toggle').click();
+  await expect(page.locator('#export-popover')).toBeVisible();
+
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.locator(itemSelector).click(),
+  ]);
+  const path = await download.path();
+  return fs.readFileSync(path, 'utf-8');
+}
+
+// csvField mirrors the server's csvEscape so we can compare predictably. Only
+// covers the inputs we actually test against (image names).
+function csvField(s) {
+  if (/[,"\n]/.test(s)) {
+    return '"' + s.replace(/"/g, '""') + '"';
+  }
+  return s;
+}


### PR DESCRIPTION
## Summary

Closes #3. Replaces the closed PR #4, which had diverged too far from current `main` to rebase cleanly (the dashboard rewrite for HTTP upload mode, Run Scan, auth, and timeline all landed after PR #4 was authored).

This PR carries PR #4's CSV + Markdown export shape *plus* one improvement worth folding in: a `?filename=` parameter so the **selected** report on the timeline is the one that gets exported, not always the latest.

## Endpoint

`GET /api/export`

| Query | Default | Notes |
| --- | --- | --- |
| `format` | `csv` | `csv` \| `markdown` \| `md` (alias) |
| `filename` | `provenance-latest.json` | Any file under `reportsDir`; path traversal rejected with `400` (same rules as `/api/reports/{filename}`) |

Returns:

- **CSV** — flat table, one row per image. Columns: `Image, Namespace, Workload Kind, Workload Name, Digest, Signed, Verified, SLSA Provenance, SBOM, SBOM Format, Update Available, Current Tag, Latest In Major`. Field values containing `, " \n` are RFC 4180 escaped.
- **Markdown** — header (generated-at, cluster, namespaces) → Summary table → Container Images table → Helm Releases table.

Both responses include `Content-Disposition: attachment; filename=provenance-report.{csv,md}` so a plain anchor link triggers a download.

## Dashboard wiring

- Nav-bar `CSV`, `MD`, `JSON` buttons next to `Run Scan`.
- `loadReport(filename)` repoints the three button `href`s at the selected report on every timeline switch, so the buttons always match the report on screen. Without this, the buttons would silently always export the latest report regardless of what the user is looking at.

## Tests

`internal/dashboard/export_test.go` (`194` lines, 10 cases):

- `TestExportCSV` — CSV header + nginx row present, `Content-Type: text/csv`, `Content-Disposition` filename
- `TestExportMarkdown` — required sections + fixture data present
- `TestExportMdShorthand` — `format=md` → `text/markdown`
- `TestExportDefaultFormat` — no format → CSV
- `TestExportUnsupportedFormat` — `format=pdf` → 400
- `TestExportNoReport` — empty dir → 404
- `TestExportFilenameParam` — explicit `filename=` returns the right file
- `TestExportFilenameNotFound` — bogus filename → 404
- `TestExportFilenamePathTraversal` — `../etc/passwd`, `subdir/file.json`, `..` → 400
- `TestCSVEscape` — comma / quote / newline / empty input table

Local `go test ./...` is green; vet + gofmt clean.

## Before / after

```bash
# Before
# No way to extract a report from outside the dashboard UI — had to read the
# PVC or ConfigMap directly.

# After
# UI: three buttons in the nav bar
# API:
curl -OJ http://localhost:8080/api/export?format=csv
curl -OJ http://localhost:8080/api/export?format=markdown
curl -OJ "http://localhost:8080/api/export?format=csv&filename=provenance-20260518-110639.json"
```

## Test plan

- [x] `go test ./...` green locally.
- [x] `gofmt -l` clean, `go vet ./...` clean.
- [x] CI green (unit-test, go-lint, helm-lint, integration).
- [x] Manually verify the dashboard nav-bar buttons download the selected report (not just latest) on a kind cluster — the timeline-switch test in `test/e2e/` doesn't currently cover export.
