### PR TITLE
ci: bump deprecated Node-20 actions to current majors

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -42,7 +42,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -45,14 +45,14 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -60,7 +60,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ghcr.io/${{ github.repository }}
@@ -83,7 +83,7 @@ jobs:
           fi
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,9 +10,9 @@ jobs:
   go-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -26,7 +26,7 @@ jobs:
   helm-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Helm
         uses: azure/setup-helm@v4

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ jobs:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.11.4
         env:
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Lint chart
         run: helm lint chart/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Helm
         uses: azure/setup-helm@v4
@@ -31,7 +31,7 @@ jobs:
     needs: lint-and-test
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Helm
         uses: azure/setup-helm@v4
@@ -81,7 +81,7 @@ jobs:
     needs: publish-helm-chart
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Helm
         uses: azure/setup-helm@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Lint chart
         run: helm lint chart/
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Update Chart version
         run: |
@@ -84,7 +84,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Update Chart version
         run: |

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -174,7 +174,7 @@ jobs:
       # having to re-run anything locally.
       - name: Upload Playwright artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-artifacts
           path: |
@@ -240,7 +240,7 @@ jobs:
 
       - name: Upload screenshots as artifacts
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dashboard-screenshots
           path: docs/screenshots/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,9 +10,9 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -21,7 +21,7 @@ jobs:
 
       - name: Upload coverage
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage.out


### PR DESCRIPTION
## Summary

Closes #26. Bumps every action that emits the Node-20 deprecation warning to its current Node-24-compatible major. Mechanical version-tag swap across all five workflows — no usage changes.

```
Node.js 20 actions are deprecated. ... will be forced to run with Node.js 24
by default starting June 2nd, 2026. Node.js 20 will be removed from the
runner on September 16th, 2026.
```

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Bumps

| Action | Old | New | Where |
| --- | --- | --- | --- |
| `actions/checkout` | `v4` | `v6` | every workflow |
| `actions/setup-go` | `v5` | `v6` | lint, test, test-integration |
| `actions/upload-artifact` | `v4` | `v7` | test, test-integration |
| `docker/build-push-action` | `v6` | `v7` | build-image |
| `docker/login-action` | `v3` | `v4` | build-image |
| `docker/metadata-action` | `v5` | `v6` | build-image |
| `azure/setup-helm` | `v4` | `v5` | lint, release |
| `golangci/golangci-lint-action` | `v7` | `v9` | lint |

Two actions explicitly *not* in the deprecation warning are intentionally left at their current versions:

- `softprops/action-gh-release@v2`
- `nebari-dev/action-nebari-sandbox@v1`

## Out of scope

- No behavioural changes. Every action's `with:` inputs and outputs we use are unchanged across these majors.
- `release.yaml` only runs on tag-published, so its bumps can't be exercised pre-merge. The diff is the same version-tag swap as everywhere else.

## Test plan

- [x] `lint`, `test`, `unit-test`, `helm-lint`, `go-lint`, `build-and-push`, `integration`, `sync` all pass on `de393aa` (first commit, the actions/* bumps).
- [ ] Same checks pass on `2012399` (second commit, this extension).
- [ ] No more `Node.js 20 actions are deprecated` warning anywhere in the integration / lint / build-image logs.
- [ ] `golangci/golangci-lint-action@v9` still honours `version: v2.11.4` (only behaviour worth double-checking on the lint job).
