### PR TITLE
ci(release): stamp examples/*.yaml to the released version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,3 +98,47 @@ jobs:
           chart-path: chart
           chart-name: provenance-collector
           token: ${{ secrets.NEBARI_HELM_REPO_TOKEN }}
+
+  # Keep examples/*.yaml in sync with the released version so users who copy
+  # them aren't pinned to a stale chart revision. Runs after the chart is
+  # published; commits the rewritten files back to main with [skip ci] so the
+  # bump doesn't trigger another release.
+  stamp-examples:
+    name: Stamp examples to release version
+    runs-on: ubuntu-latest
+    needs: publish-helm-chart
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stamp examples with release version
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION="${TAG#v}"
+          echo "Stamping examples to ${VERSION}"
+          # ArgoCD Application targetRevision (the existing case today).
+          sed -i -E "s|^(\s*targetRevision:\s*)\"[^\"]*\"(.*)|\1\"${VERSION}\"\2|" examples/*.yaml || true
+          # Quoted `tag: "..."` lines anywhere under examples/ — covers any
+          # future helm.valuesObject.image.tag we add. Greedy on purpose:
+          # examples/ only holds files we control, and no existing key
+          # collision exists (only chart releases would land a `tag:` line
+          # at any indent today).
+          sed -i -E "s|^(\s+tag:\s*)\"[^\"]*\"(.*)|\1\"${VERSION}\"\2|" examples/*.yaml || true
+          echo "--- diff ---"
+          git diff examples/ || true
+
+      - name: Commit and push to main
+        run: |
+          if git diff --quiet examples/; then
+            echo "No example files needed updating."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add examples/
+          git commit -m "chore: stamp examples to ${{ github.event.release.tag_name }} [skip ci]"
+          git push


### PR DESCRIPTION
## Summary

Closes #20. Adds a release-workflow job that stamps `examples/*.yaml` with the released version and commits the result back to `main`, so users who copy from `examples/` don't get pinned to a stale chart revision.

## The problem this solves

Every release today leaves [`examples/argocd-application.yaml`](../blob/main/examples/argocd-application.yaml) with `targetRevision: "0.1.0"` — the comment on that line literally says *"Update repoURL and targetRevision once the chart is published"*, but that update never happens. As of `v0.1.0-alpha.4` the example was already wrong.

## What's added

A new `stamp-examples` job at the end of `.github/workflows/release.yaml`, depends on `publish-helm-chart`:

1. `actions/checkout@v6` with `ref: main` (so the commit lands on `main`'s tip, not the released tag's SHA).
2. Two `sed -i -E` rewrites against `examples/*.yaml`:
   - `targetRevision: "..."` (the existing case)
   - `tag: "..."` at any indent (future-proofing — no current file has this, but the issue calls out that any future `image.tag` will face the same drift)
3. If `git diff --quiet examples/` (nothing changed), exit `0` silently.
4. Otherwise, commit with `[skip ci]` and `git push`. The skip-ci tag avoids the push triggering another release cycle.

## Tested locally

```
$ VERSION="0.1.0-alpha.4"
$ sed -i -E "s|^(\s*targetRevision:\s*)\"[^\"]*\"(.*)|\1\"${VERSION}\"\2|" examples/argocd-application.yaml

$ git diff examples/argocd-application.yaml
-    targetRevision: "0.1.0"  # Pin to a released version.
+    targetRevision: "0.1.0-alpha.4"  # Pin to a released version.
```

The trailing comment is preserved. The greedy `tag:` regex makes no changes against current `examples/*.yaml` (no match), so it's a no-op until someone adds an image-tag pin.

## What's deliberately not stamped

- `chart/Chart.yaml` — its `version` / `appVersion` already get bumped in-process during the workflow run (see lines 39–43 of `release.yaml`), but the bumped Chart.yaml is *not* committed back to `main`. That's a separate drift issue and out of scope here.
- `README.md` install snippets — already use the `nebari/provenance-collector` helm repo entry with no version pin.
- `.github/release-template.md` — uses `${VERSION}` placeholders substituted at release time, so it's already dynamic.

## Test plan

This workflow only runs on `release: published`, so it can't be exercised end-to-end pre-merge. Validation done so far:

- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` parses the workflow cleanly; the new job has the expected `[Checkout main, Stamp examples..., Commit and push to main]` step shape.
- [x] Sed dry-run against current `examples/argocd-application.yaml` produces the expected diff with the comment preserved.
- [x] Standard CI checks (lint, test, helm-lint, integration) pass — release workflow changes don't trigger them, but the diff is YAML-only.
- [ ] First post-merge release will exercise the new job. If the sed misses or over-matches anything, the workflow's diff output (`echo "--- diff ---"; git diff examples/`) will surface it in the job log.

## Follow-up issues this *doesn't* address

- `chart/Chart.yaml` staying at `0.1.0` on `main` between releases — out of scope.
- Auto-update of any version pins in `README.md` / `docs/` — none exist today; defer until we add one.
