### PR TITLE
ci(image): attach SBOM + SLSA on every build

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -41,6 +41,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # Required for keyless cosign OIDC signing on release.
+      id-token: write
     steps:
       - uses: actions/checkout@v6
 
@@ -83,6 +85,7 @@ jobs:
           fi
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -91,3 +94,35 @@ jobs:
             VERSION=${{ steps.version.outputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Attach an SPDX SBOM and a SLSA provenance attestation as OCI
+          # referrers on every build, in both registries. The collector's own
+          # internal/verify/sbom.go and internal/verify/provenance.go look for
+          # these via the OCI referrers API — without them, our own image would
+          # show up as "no SBOM, no provenance" when scanned by us (#29).
+          sbom: true
+          provenance: mode=max
+
+      # Cosign signing is release-only. Every build gets attestations (above),
+      # but we don't sign per-PR / per-main-commit images because those tags
+      # roll over fast and the signatures would litter Rekor. Sign only the
+      # stable release tags so consumers can `cosign verify` against
+      # canonical artifacts.
+      - name: Install cosign
+        if: github.event_name == 'release'
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign released images (keyless)
+        if: github.event_name == 'release'
+        env:
+          # Sign by digest, not tag. The build output digest is identical
+          # across registries because it's a content digest; we just point
+          # cosign at the right registry path for each.
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -eu
+          for repo in \
+            "ghcr.io/${{ github.repository }}" \
+            "quay.io/nebari/provenance-collector"; do
+            echo "Signing ${repo}@${DIGEST}"
+            cosign sign --yes "${repo}@${DIGEST}"
+          done

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -41,8 +41,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      # Required for keyless cosign OIDC signing on release.
-      id-token: write
     steps:
       - uses: actions/checkout@v6
 
@@ -91,7 +89,6 @@ jobs:
           fi
 
       - name: Build and push
-        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -107,28 +104,3 @@ jobs:
           # show up as "no SBOM, no provenance" when scanned by us (#29).
           sbom: true
           provenance: mode=max
-
-      # Cosign signing is release-only. Every build gets attestations (above),
-      # but we don't sign per-PR / per-main-commit images because those tags
-      # roll over fast and the signatures would litter Rekor. Sign only the
-      # stable release tags so consumers can `cosign verify` against
-      # canonical artifacts.
-      - name: Install cosign
-        if: github.event_name == 'release'
-        uses: sigstore/cosign-installer@v3
-
-      - name: Sign released images (keyless)
-        if: github.event_name == 'release'
-        env:
-          # Sign by digest, not tag. The build output digest is identical
-          # across registries because it's a content digest; we just point
-          # cosign at the right registry path for each.
-          DIGEST: ${{ steps.build.outputs.digest }}
-        run: |
-          set -eu
-          for repo in \
-            "ghcr.io/${{ github.repository }}" \
-            "quay.io/nebari/provenance-collector"; do
-            echo "Signing ${repo}@${DIGEST}"
-            cosign sign --yes "${repo}@${DIGEST}"
-          done

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -48,7 +48,7 @@ jobs:
       # (sbom: true, provenance: mode=max). The default docker driver errors
       # out with "Attestation is not supported for the docker driver."
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
         uses: docker/login-action@v4

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -46,6 +46,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Buildx needs the docker-container driver to attach OCI attestations
+      # (sbom: true, provenance: mode=max). The default docker driver errors
+      # out with "Attestation is not supported for the docker driver."
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:


### PR DESCRIPTION
## Summary

Towards #29 — attaches SPDX SBOM and SLSA provenance attestations to every collector image build, in both registries. **Image signing is intentionally deferred** to a separate discussion (the cosign / Sigstore ecosystem choice deserves its own thread before we commit to it).

The collector reports on cosign signatures, SBOMs, and SLSA provenance, but our own image shipped without any of them. Scanning a cluster running this chart showed the collector image in the "unsigned / no SBOM / no SLSA" state — undermining every demo screenshot. This PR fixes the attestation half of that gap.

## What changes

Two edits in `.github/workflows/build-image.yaml`:

### 1. Buildx with the `docker-container` driver

The default `docker` driver buildx uses on a fresh runner errors out with `Attestation is not supported for the docker driver`. Adding `docker/setup-buildx-action@v3` before the build switches to the `docker-container` driver, which does support OCI attestations.

### 2. SBOM + SLSA attached on every build

```yaml
- name: Build and push
  uses: docker/build-push-action@v7
  with:
    ...
    sbom: true            # SPDX as an OCI referrer
    provenance: mode=max  # SLSA provenance with full builder info
```

Both push to ghcr.io and quay.io alongside the image manifest. `internal/verify/sbom.go` and `internal/verify/provenance.go` already detect these via the OCI referrers API — no collector code changes.

Attestations are on for **every** build (PR / main / release) since they're effectively free and let the dashboard see them in integration tests too.

## What's deliberately not in here

- **Cosign signing.** Originally drafted as a `release-only` keyless cosign step (Sigstore / Fulcio OIDC), but the ecosystem choice is broader than this PR. Defer to a dedicated discussion under #29.
- **README / screenshot refresh** showing the collector image with green badges. Will land naturally on the next release-after-merge when the screenshot job re-captures.

## Acceptance for the half this PR delivers

```bash
# After a release tag publishes:
docker buildx imagetools inspect \
  --format '{{ json .Provenance }}' \
  quay.io/nebari/provenance-collector:<version>
# Must show a populated SLSA provenance object.

docker buildx imagetools inspect \
  --format '{{ json .SBOM }}' \
  quay.io/nebari/provenance-collector:<version>
# Must show a SPDX SBOM with package data.
```

Then in a running dashboard, the collector's own row should show **SLSA** / **SPDX** badges. Signed / Verified will stay muted until the signing PR lands.

## Test plan

- [x] `build-and-push` passes on the PR — confirms `sbom: true` + `provenance: mode=max` push successfully to both registries with the `docker-container` driver.
- [ ] After merge, the next built `pr-*` image carries the attestations (verifiable via `docker buildx imagetools inspect ...` from CLI).
- [ ] After the next release tag, the integration test should be able to assert positive SBOM / SLSA signals on the collector's own row (separate spec addition, not in this PR).
