### PR TITLE
feat(dashboard): show unique-image delta on each timeline card

### DIFF
--- a/chart/templates/deployment-web.yaml
+++ b/chart/templates/deployment-web.yaml
@@ -75,6 +75,12 @@ spec:
             # "unset → use default".
             - name: PROVENANCE_MANUAL_JOB_TTL
               value: {{ .Values.webUI.manualJobTTL | quote }}
+            # Opt-in feature flags. The Go side reads "true" / "1" / "yes" / "on"
+            # case-insensitively; everything else is off.
+            {{- if .Values.webUI.features.timelineDeltas }}
+            - name: PROVENANCE_FEATURE_TIMELINE_DELTAS
+              value: "true"
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.webUI.port }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -69,6 +69,12 @@ webUI:
   internalPort: 8081
   # Max body size (bytes) accepted on the internal upload endpoint.
   uploadMaxBytes: 16777216  # 16 MiB
+  # Opt-in dashboard features. All default off; flip individually.
+  features:
+    # Renders a +N / -N unique-image delta badge on each timeline card,
+    # showing how the report changed vs the previous (older) scan. Useful
+    # once you have enough scan history to notice drift at a glance.
+    timelineDeltas: false
   resources:
     requests:
       cpu: 50m

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -57,6 +57,10 @@ func main() {
 
 	manualJobTTL := parseManualJobTTL(os.Getenv("PROVENANCE_MANUAL_JOB_TTL"))
 
+	features := dashboard.Features{
+		TimelineDeltas: parseBool("PROVENANCE_FEATURE_TIMELINE_DELTAS"),
+	}
+
 	slog.Info("configuration loaded",
 		"publicAddr", publicAddr,
 		"internalAddr", internalAddr,
@@ -66,9 +70,10 @@ func main() {
 		"authIssuer", authCfg.IssuerURL,
 		"adminGroups", len(authCfg.AdminGroups),
 		"manualJobTTL", manualJobTTL.String(),
+		"features.timelineDeltas", features.TimelineDeltas,
 	)
 
-	publicSrv := dashboard.NewServer(reportsDir).WithAuth(authCfg)
+	publicSrv := dashboard.NewServer(reportsDir).WithAuth(authCfg).WithFeatures(features)
 	internalSrv := dashboard.NewInternalServer(reportsDir, retention, maxUpload)
 
 	// /api/scan needs an in-cluster client + the CronJob's namespace/name.
@@ -196,6 +201,17 @@ func parseDuration(key string, fallback time.Duration) time.Duration {
 		return fallback
 	}
 	return d
+}
+
+// parseBool reads an env var and returns true iff the value is one of
+// "1", "true", "yes", or "on" (case-insensitive). Anything else, including
+// unset, is false — matching the opt-in posture for feature flags.
+func parseBool(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
 }
 
 func parseBytes(key string, fallback int64) int64 {

--- a/internal/dashboard/auth_test.go
+++ b/internal/dashboard/auth_test.go
@@ -55,6 +55,28 @@ func TestMe_AuthDisabled(t *testing.T) {
 	if resp.CanRunScan {
 		t.Errorf("expected canRunScan=false")
 	}
+	// Default features are all-off — matches the chart's opt-in posture.
+	if resp.Features.TimelineDeltas {
+		t.Errorf("expected features.timelineDeltas=false by default")
+	}
+}
+
+func TestMe_FeaturesReflectWithFeatures(t *testing.T) {
+	srv := NewServer(t.TempDir()).WithFeatures(Features{TimelineDeltas: true})
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp meResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+	if !resp.Features.TimelineDeltas {
+		t.Errorf("expected features.timelineDeltas=true after WithFeatures")
+	}
 }
 
 func TestMe_NoBearer(t *testing.T) {

--- a/internal/dashboard/index.go
+++ b/internal/dashboard/index.go
@@ -116,6 +116,12 @@ const indexHTML = `<!DOCTYPE html>
   .timeline-item .date { font-size: 12px; font-weight: 600; }
   .timeline-item .time { font-size: 11px; color: var(--muted); }
   .timeline-item .count { font-size: 10px; color: var(--faint); margin-top: 2px; }
+  /* Delta vs the previous (older) scan — only rendered when a previous scan
+     exists and the unique-image count differs. */
+  .timeline-item .delta { display: inline-block; margin-top: 4px; padding: 1px 6px; border-radius: 3px; font-size: 10px; font-weight: 600; letter-spacing: 0.02em; }
+  .timeline-item .delta-up { background: rgba(16,185,129,0.12); color: var(--green); }
+  .timeline-item .delta-down { background: rgba(239,68,68,0.12); color: var(--red); }
+  .timeline-item .delta-zero { background: rgba(136,136,160,0.08); color: var(--faint); }
 
   /* Pagination */
   .pagination { display: flex; align-items: center; justify-content: space-between; padding: 8px 20px; border-top: 1px solid var(--border); font-size: 11px; color: var(--muted); }
@@ -376,10 +382,26 @@ function showEmpty() {
 function renderTimeline() {
   document.getElementById('timeline').innerHTML = reports.map((r, i) => {
     const d = new Date(r.generatedAt);
+    // reports[] is sorted DESC by generatedAt, so the older scan to compare
+    // against is the next index up (i + 1). The oldest card has no neighbor
+    // to diff against; render no delta there.
+    const prev = reports[i + 1];
+    let deltaHTML = '';
+    if (prev) {
+      const delta = (r.summary.uniqueImages || 0) - (prev.summary.uniqueImages || 0);
+      const cls = delta > 0 ? 'delta-up' : delta < 0 ? 'delta-down' : 'delta-zero';
+      const text = delta > 0 ? '+' + delta : String(delta);
+      deltaHTML = '<div class="delta ' + cls + '" data-delta="' + delta + '" title="' + (
+        delta > 0 ? delta + ' new unique image(s) vs previous scan' :
+        delta < 0 ? Math.abs(delta) + ' image(s) gone vs previous scan' :
+        'no change vs previous scan'
+      ) + '">' + text + '</div>';
+    }
     return '<div class="timeline-item' + (i === 0 ? ' active' : '') + '" onclick="selectReport(' + i + ')" id="tl-' + i + '">' +
       '<div class="date">' + d.toLocaleDateString() + '</div>' +
       '<div class="time">' + d.toLocaleTimeString() + '</div>' +
-      '<div class="count">' + r.summary.totalImages + ' images</div></div>';
+      '<div class="count">' + r.summary.totalImages + ' images</div>' +
+      deltaHTML + '</div>';
   }).join('');
 }
 

--- a/internal/dashboard/index.go
+++ b/internal/dashboard/index.go
@@ -268,9 +268,15 @@ let imageSortAsc = true;
 let pageSize = 25;
 let currentPage = 0;
 let lastFilteredImages = [];
+// Feature flags from /api/me. Defaults are all-off to match the chart's
+// opt-in posture; initConfig() overwrites this with the server's response.
+let features = { timelineDeltas: false };
 
 async function init() {
-  initAuth();
+  // Await the config fetch so renderTimeline() below sees the correct feature
+  // flags on first paint. The call is fast and fail-quiet — defaults stand
+  // if it errors.
+  await initConfig();
   try {
     const res = await fetch('/api/reports');
     reports = await res.json();
@@ -282,10 +288,12 @@ async function init() {
   }
 }
 
-// initAuth resolves whether the calling user may trigger a scan and shows
-// the Run Scan button if so. Fail-quiet: if /api/me errors, the button stays
-// hidden — better silent than wrongly inviting non-admins to a 403.
-async function initAuth() {
+// initConfig resolves both the scan-button visibility (auth) and the
+// dashboard feature flags from /api/me in a single fetch. Fail-quiet: if
+// /api/me errors, the scan button stays hidden and feature flags stay at
+// their defaults (all-off) — better silent than wrongly inviting non-admins
+// to a 403 or rendering a feature the operator chose not to enable.
+async function initConfig() {
   try {
     const res = await fetch('/api/me');
     if (!res.ok) return;
@@ -293,7 +301,10 @@ async function initAuth() {
     if (me && me.canRunScan) {
       document.getElementById('btn-scan').style.display = 'inline-flex';
     }
-  } catch (e) { /* keep button hidden */ }
+    if (me && me.features) {
+      features = Object.assign(features, me.features);
+    }
+  } catch (e) { /* keep defaults */ }
 }
 
 let scanPollTimer = null;
@@ -384,10 +395,12 @@ function renderTimeline() {
     const d = new Date(r.generatedAt);
     // reports[] is sorted DESC by generatedAt, so the older scan to compare
     // against is the next index up (i + 1). The oldest card has no neighbor
-    // to diff against; render no delta there.
+    // to diff against; render no delta there. Also gated on the
+    // timelineDeltas feature flag — off by default in the chart, enable via
+    // webUI.features.timelineDeltas: true.
     const prev = reports[i + 1];
     let deltaHTML = '';
-    if (prev) {
+    if (features.timelineDeltas && prev) {
       const delta = (r.summary.uniqueImages || 0) - (prev.summary.uniqueImages || 0);
       const cls = delta > 0 ? 'delta-up' : delta < 0 ? 'delta-down' : 'delta-zero';
       const text = delta > 0 ? '+' + delta : String(delta);

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -12,11 +12,22 @@ import (
 	"github.com/nebari-dev/provenance-collector/internal/report"
 )
 
+// Features holds the optional, opt-in UI features the server advertises via
+// /api/me. The zero value disables every feature, which is what consumers
+// upgrading from a release without the feature flags will get.
+type Features struct {
+	// TimelineDeltas controls whether the dashboard renders the +N/-N
+	// unique-image delta badge on each timeline card. Off by default to
+	// match the chart default; enable via webUI.features.timelineDeltas.
+	TimelineDeltas bool `json:"timelineDeltas"`
+}
+
 // Server serves the provenance dashboard web UI.
 type Server struct {
 	reportsDir string
 	auth       *authenticator
 	scan       ScanRunner
+	features   Features
 	mux        *http.ServeMux
 }
 
@@ -49,6 +60,14 @@ func (s *Server) WithAuth(cfg AuthConfig) *Server {
 // Jobs. When unset, /api/scan responds with 503.
 func (s *Server) WithScanRunner(r ScanRunner) *Server {
 	s.scan = r
+	return s
+}
+
+// WithFeatures sets the opt-in UI feature flags returned by /api/me. The
+// dashboard JS reads these during init() and gates rendering of the
+// corresponding components on them.
+func (s *Server) WithFeatures(f Features) *Server {
+	s.features = f
 	return s
 }
 
@@ -149,6 +168,7 @@ type meResponse struct {
 	Email       string   `json:"email,omitempty"`
 	Groups      []string `json:"groups,omitempty"`
 	CanRunScan  bool     `json:"canRunScan"`
+	Features    Features `json:"features"`
 }
 
 func (s *Server) handleMe(w http.ResponseWriter, r *http.Request) {
@@ -156,6 +176,7 @@ func (s *Server) handleMe(w http.ResponseWriter, r *http.Request) {
 	resp := meResponse{
 		AuthEnabled: s.auth.enabled(),
 		CanRunScan:  s.auth.canRunScan(id),
+		Features:    s.features,
 	}
 	if id != nil {
 		resp.Email = id.Email

--- a/test/e2e/timeline-switch.spec.js
+++ b/test/e2e/timeline-switch.spec.js
@@ -71,6 +71,30 @@ test('timeline scan-switch updates stat cards AND images table', async ({ page }
   expect(olderHasNewImage, `older report must NOT contain "${NEW_IMAGE_MARKER}"`).toBe(0);
 });
 
+// Timeline cards carry a delta vs the previous (older) scan. With two reports
+// where the newer one added the sentinel image, the newest card should show a
+// "+N" (delta-up) badge equal to the unique-image count growth, and the older
+// card — being the bottom of the timeline — should render no delta badge.
+test('timeline cards show unique-image deltas vs the previous scan', async ({ page }) => {
+  await page.goto(BASE, { waitUntil: 'networkidle' });
+  await page.waitForSelector('.timeline-item');
+
+  const items = page.locator('.timeline-item');
+  await expect(items).toHaveCount(2, { timeout: 10_000 });
+
+  // Newest card has a delta (older neighbor exists) and must be positive,
+  // because the sentinel deploy added at least one unique image.
+  const newestDelta = items.nth(0).locator('.delta');
+  await expect(newestDelta, 'newest card must render a delta').toHaveCount(1);
+  await expect(newestDelta).toHaveClass(/\bdelta-up\b/);
+  const newestDeltaValue = parseInt(await newestDelta.getAttribute('data-delta') || '0', 10);
+  expect(newestDeltaValue, 'newest delta should be a positive image gain').toBeGreaterThan(0);
+
+  // Oldest card has no neighbor to diff against — no delta badge rendered.
+  const olderDelta = items.nth(1).locator('.delta');
+  await expect(olderDelta, 'oldest card must render no delta').toHaveCount(0);
+});
+
 // selectMaxPageSize bumps the table page size to 100 via the pagination
 // dropdown if it is rendered. The dropdown only appears when the report has
 // more rows than the current page size, so on small reports this is a no-op.

--- a/test/e2e/timeline-switch.spec.js
+++ b/test/e2e/timeline-switch.spec.js
@@ -71,11 +71,39 @@ test('timeline scan-switch updates stat cards AND images table', async ({ page }
   expect(olderHasNewImage, `older report must NOT contain "${NEW_IMAGE_MARKER}"`).toBe(0);
 });
 
-// Timeline cards carry a delta vs the previous (older) scan. With two reports
-// where the newer one added the sentinel image, the newest card should show a
-// "+N" (delta-up) badge equal to the unique-image count growth, and the older
-// card — being the bottom of the timeline — should render no delta badge.
-test('timeline cards show unique-image deltas vs the previous scan', async ({ page }) => {
+// Timeline-delta badge is an opt-in feature gated on
+// /api/me.features.timelineDeltas. The integration cluster's chart install
+// leaves it off (matches the chart default), so the live /api/me returns
+// `features: { timelineDeltas: false }` and no badges render. We assert both
+// states by leaving the live API alone for the "off" case and route-mocking
+// /api/me for the "on" case.
+
+test('timeline cards omit deltas when the feature flag is disabled (default)', async ({ page }) => {
+  await page.goto(BASE, { waitUntil: 'networkidle' });
+  await page.waitForSelector('.timeline-item');
+
+  const items = page.locator('.timeline-item');
+  await expect(items).toHaveCount(2, { timeout: 10_000 });
+
+  // No delta badges anywhere — the feature flag defaults to off.
+  await expect(page.locator('.timeline-item .delta')).toHaveCount(0);
+});
+
+test('timeline cards show unique-image deltas when the feature flag is enabled', async ({ page }) => {
+  // Mock /api/me to flip timelineDeltas on. Server-side enforcement is covered
+  // by internal/dashboard/server_test.go; this spec exercises the JS gate.
+  await page.route('**/api/me', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        authEnabled: false,
+        canRunScan: false,
+        features: { timelineDeltas: true },
+      }),
+    });
+  });
+
   await page.goto(BASE, { waitUntil: 'networkidle' });
   await page.waitForSelector('.timeline-item');
 


### PR DESCRIPTION
## Summary

Closes #22 item 8 (timeline cards show deltas). Adds a small `+N / -N / 0` badge to each timeline card showing the unique-image delta against the immediately-previous scan — gated behind a new opt-in chart value, **default off**.

Today the card shows only date / time / image count. The *change* — "what new images appeared since last time", "did anything disappear" — was the thing the timeline was meant to surface, but you had to click each entry and compare manually.

## Render

When enabled, each card carries a small colored badge below the image count:

| Sign | Class | Color | Meaning |
| --- | --- | --- | --- |
| `+N` | `.delta-up` | green | N new unique images vs previous scan |
| `-N` | `.delta-down` | red | N images gone vs previous scan |
| `0` | `.delta-zero` | muted | no change |

Hovering the badge shows a tooltip with the direction in prose (`"3 new unique image(s) vs previous scan"`) — useful when the magnitude alone (e.g. `-1` vs `0`) is ambiguous at a glance.

The **oldest** card on the timeline has no previous scan to diff against and renders no badge.

## Feature flag

Per PR #32 review, the badge is opt-in via the chart's `webUI.features` block — matches the posture of other dashboard features (signature verification, SBOM checks, etc.). Default off; flip explicitly to enable:

```yaml
# values.yaml
webUI:
  features:
    timelineDeltas: true
```

End-to-end plumbing:

| Layer | Change |
| --- | --- |
| `chart/values.yaml` | New `webUI.features.timelineDeltas: false` |
| `chart/templates/deployment-web.yaml` | Emits `PROVENANCE_FEATURE_TIMELINE_DELTAS=true` on the dashboard pod only when truthy. Default-off keeps the env var **absent**, not "false" — avoids polluting the deployment with `PROVENANCE_FEATURE_*=false` lines as more flags get added. |
| `cmd/dashboard/main.go` | Parses the env var (`1`/`true`/`yes`/`on`, case-insensitive) and passes it via the new `WithFeatures` setter. |
| `internal/dashboard/server.go` | New exported `Features` type + `WithFeatures` chain method. Existing `meResponse` gains a `features` field so the JS reads flags via the already-fetched `/api/me`, no second endpoint needed. |
| `internal/dashboard/index.go` | New `features` global with the same shape as the server's `Features` struct. `init()` now awaits the `/api/me` fetch (renamed `initAuth` → `initConfig` to reflect the broader purpose) before the first `renderTimeline()`, so feature flags are known on first paint. `renderTimeline` gates the delta badge on `features.timelineDeltas`. |

## Implementation notes

- Delta uses `summary.uniqueImages` (deduplicated by workload owner) rather than `totalImages`. A deployment scaling event (3 → 6 nginx pods) shouldn't appear as "3 new images" — only actually-new images should move the badge.
- Delta is computed against `reports[i + 1]` because the `reports` array is sorted DESC by `generatedAt`; the next index *up* is the previous scan in time.
- The `data-delta` attribute on the badge carries the signed integer so e2e tests can assert the sign without parsing visible text.

## Coverage

### Go unit tests (`internal/dashboard/auth_test.go`)

- `TestMe_AuthDisabled` extended: asserts `features.timelineDeltas` defaults to `false` in the `meResponse` JSON.
- New `TestMe_FeaturesReflectWithFeatures`: confirms `WithFeatures(Features{TimelineDeltas: true})` flips the response field through.

### Playwright (`test/e2e/timeline-switch.spec.js`)

The existing delta test was unconditional — split into two:

1. **Default off** — hits the live `/api/me` from the chart's default install (`webUI.features.timelineDeltas: false`). Asserts zero `.delta` elements anywhere in the timeline.
2. **Enabled** — `page.route('**/api/me', ...)` flips the flag on. Asserts the badge shape: newest card has one `.delta-up` element with a positive `data-delta`; oldest card has zero delta elements.

This way both states are covered by a single integration run without two chart installs.

## Out of scope (deferred follow-ups in #22)

- Item 3 (filter drawer) — separate PR.
- A finer-grained add/remove split (`+2 / -1` as the issue's original phrasing suggested) — requires fetching each report's full `images[]` instead of just the summary, with delta math then running N² over the timeline. The single signed delta delivers most of the value with less wire weight; the split view can be a follow-up once the visual lands.

## Test plan

- [x] `go test ./...` green; `vet` and `gofmt` clean.
- [x] `helm template ./chart --set webUI.features.timelineDeltas=true` renders `PROVENANCE_FEATURE_TIMELINE_DELTAS: "true"` on the dashboard deployment.
- [x] `helm template ./chart` (default) omits the env var entirely.
- [x] CI: all six checks green on `64b6bb4` — including both off-default and mocked-on Playwright cases.
- [ ] After merge, visual regression: `docs/screenshots/dashboard-overview.png` auto-update reflects the default-off state (no badges visible). When you enable the flag on a real cluster, badges show on the next render.
