### PR TITLE
docs(readme): lead Quick Start with operator-managed path + refresh dashboard sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,16 @@ kubectl get pods -n provenance-system -l app.kubernetes.io/name=provenance-colle
 
 #### Trigger a manual run
 
+Two options:
+
+1. **From the dashboard** — click the `Run Scan` button next to the timeline.
+   The button only renders for users whose OIDC groups intersect with
+   `webUI.adminGroups`, so it's hidden by default until you wire up
+   `webUI.oidcIssuer` and at least one admin group. Under operator-managed
+   installs (`nebariapp.enabled: true`) this is handled automatically — the
+   operator routes through Keycloak with the groups in `nebariapp.auth.groups`.
+2. **With `kubectl`** — fall back to creating a Job from the CronJob directly:
+
 ```bash
 kubectl create job --from=cronjob/provenance-collector \
   manual-run -n provenance-system
@@ -199,6 +209,11 @@ kubectl create job --from=cronjob/provenance-collector \
 kubectl wait --for=condition=complete job/manual-run \
   -n provenance-system --timeout=5m
 ```
+
+Either path creates a one-shot Job from the same CronJob template, so the
+resulting report is identical. Manual Jobs are auto-cleaned after
+`webUI.manualJobTTL` (default 1h); the kubectl-created Job above has no TTL
+and persists until you delete it.
 
 #### View the report
 
@@ -260,14 +275,18 @@ kubectl port-forward svc/provenance-collector-web 8080:8080 -n provenance-system
 
 The dashboard provides:
 
-- Summary stat cards (signed %, SLSA provenance, SBOM, updates available)
-- Report timeline to browse historical reports
-- Filterable, sortable, paginated image table
+- Summary stat cards (`N / M` ratios for Signed, Verified, SLSA, SBOM; absolute counts for Images, Updates, Helm)
+- Report timeline to browse historical reports, with an opt-in `+N / -N` unique-image delta badge between adjacent scans (`webUI.features.timelineDeltas`)
+- Filterable, sortable, paginated image table (sticky column header, truncated workload column with full name on hover)
 - Click any image row for a detail panel showing signature, SLSA, SBOM, and update info
 - Helm releases table
+- **Run Scan** button — admin-gated; triggers a one-shot Job from the same CronJob template the schedule uses. Hidden unless `webUI.oidcIssuer` is set and the calling user's OIDC groups intersect with `webUI.adminGroups`. Auto-cleanup after `webUI.manualJobTTL` (default 1h).
+- **Export** button (`CSV` / `Markdown` / `JSON`) — downloads whichever report is currently selected on the timeline, not just the latest
 
 When deployed with `nebariapp.enabled: true`, the dashboard is accessible through the
-Nebari gateway with OIDC authentication.
+Nebari gateway with OIDC authentication, and the operator wires `webUI.oidcIssuer` /
+`webUI.adminGroups` from the `nebariapp.auth` block so Run Scan and other admin
+features light up for users in the configured groups.
 
 ### Dashboard API
 
@@ -278,6 +297,9 @@ The web dashboard exposes a JSON API that can be used by external tools:
 | `GET /api/reports` | List all reports (newest first) with summary |
 | `GET /api/reports/latest` | Get the most recent report |
 | `GET /api/reports/<filename>` | Get a specific report by filename |
+| `GET /api/export?format=csv\|markdown\|md` | Render the selected report as CSV or Markdown. Optional `&filename=<file>` to pin a historical report; defaults to latest. |
+| `GET /api/me` | Calling user's identity + feature flags. Returns `authEnabled`, `canRunScan`, `features.timelineDeltas`. |
+| `POST /api/scan` | Trigger a manual scan Job. 403 if the caller isn't in an admin group, 503 if `PROVENANCE_NAMESPACE` / `PROVENANCE_CRONJOB_NAME` aren't configured. |
 | `GET /healthz` | Health check |
 
 ## Grafana Integration
@@ -418,6 +440,13 @@ persistence:
 
 webUI:
   enabled: true               # Required in http mode (hosts the upload endpoint)
+  # OIDC wiring for the Run Scan button. Auto-set by the operator under
+  # nebariapp.enabled=true; supply manually on standalone installs.
+  oidcIssuer: ""              # e.g. https://keycloak.example.com/realms/nebari
+  adminGroups: []             # OIDC group(s) allowed to click Run Scan
+  manualJobTTL: "1h"          # Auto-clean dashboard-triggered Jobs; "0" to keep
+  features:
+    timelineDeltas: false     # Opt-in; show +N/-N badges between scans
 
 # Nebari integration (optional)
 nebariapp:

--- a/README.md
+++ b/README.md
@@ -104,11 +104,54 @@ configured sink.
 
 ## Quick Start
 
-> In a full Nebari / NIC deployment the chart is managed by the Nebari Operator and ArgoCD — you do not need to
-> install it manually. See [`examples/`](examples/) for the operator-managed path. The steps below are for
-> standalone clusters and local development.
+The Provenance Collector is normally installed by the [Nebari Operator](https://github.com/nebari-dev/nebari-operator)
+as part of NIC's foundational software — you don't run any `helm` commands yourself, the operator and ArgoCD do it
+for you. The operator-managed path is the supported default; the standalone install below exists for vanilla
+Kubernetes clusters and local development.
 
-### Prerequisites
+### Operator-managed install (default)
+
+A complete ArgoCD `Application` manifest lives at [`examples/argocd-application.yaml`](examples/argocd-application.yaml)
+and is auto-stamped to the latest released chart version on every release. Apply it from your gitops repo or
+directly:
+
+```bash
+kubectl apply -f examples/argocd-application.yaml
+```
+
+The values most users adjust:
+
+```yaml
+nebariapp:
+  enabled: true                       # register the pack with the Nebari Operator
+  hostname: provenance.<your-domain>  # public URL the dashboard responds on
+
+webUI:
+  enabled: true                       # default true; required when persistence.mode=http
+  features:
+    timelineDeltas: false             # opt-in; show +N/-N badges between scans
+```
+
+Verify:
+
+```bash
+# Application picked up by ArgoCD
+kubectl get application provenance-collector -n argocd
+
+# Chart unpacked: CronJob + dashboard pods exist in the target namespace
+kubectl get cronjob -n provenance-system
+kubectl get pods -n provenance-system -l app.kubernetes.io/name=provenance-collector
+```
+
+The operator wires routing (Envoy Gateway), OIDC (Keycloak), and surfaces the dashboard on the
+[Nebari Landing](https://github.com/nebari-dev/nebari-landing) page — no extra config needed beyond `hostname`.
+
+### Standalone install (without the Nebari Operator)
+
+> Use this path only on a vanilla Kubernetes cluster *without* NIC. Without the operator you're responsible for
+> routing and OIDC yourself if you want the dashboard reachable from outside the cluster.
+
+#### Prerequisites
 
 | Tool | Minimum version | Notes |
 | --- | --- | --- |
@@ -116,9 +159,12 @@ configured sink.
 | `helm` | 3.14+ | Chart install |
 | Kubernetes cluster | 1.26+ | Local (kind / k3d / minikube) or remote |
 | Cluster permissions | `cluster-admin` | Chart creates a `ClusterRole` + `ClusterRoleBinding` |
-| Nebari Operator CRDs | optional | Required only when `nebariapp.enabled=true` (see [docs/nebariapp-crd-reference.md](docs/nebariapp-crd-reference.md)) |
 
-### Install
+> If you want `nebariapp.enabled: true` on a standalone cluster, the Nebari Operator CRDs must still be installed
+> first — see [docs/nebariapp-crd-reference.md](docs/nebariapp-crd-reference.md). Most standalone installs leave
+> `nebariapp.enabled: false` and access the dashboard via `kubectl port-forward`.
+
+#### Install
 
 ```bash
 helm repo add nebari https://nebari-dev.github.io/helm-repository
@@ -137,14 +183,14 @@ helm install provenance-collector ./chart \
   --create-namespace
 ```
 
-### Verify
+#### Verify
 
 ```bash
 kubectl get cronjob -n provenance-system
 kubectl get pods -n provenance-system -l app.kubernetes.io/name=provenance-collector
 ```
 
-### Trigger a Manual Run
+#### Trigger a manual run
 
 ```bash
 kubectl create job --from=cronjob/provenance-collector \
@@ -154,7 +200,7 @@ kubectl wait --for=condition=complete job/manual-run \
   -n provenance-system --timeout=5m
 ```
 
-### View the Report
+#### View the report
 
 ```bash
 # Default (persistence.mode=http) — read from the dashboard.
@@ -171,7 +217,7 @@ kubectl get configmap provenance-report \
   -o jsonpath='{.data.report\.json}' | jq .
 ```
 
-### Uninstall
+#### Uninstall
 
 ```bash
 helm uninstall provenance-collector -n provenance-system


### PR DESCRIPTION
## Summary

Closes #21. Two coherent README edits bundled into one PR — same reader-path / no code touched:

1. **Quick Start restructure** — operator-managed install is now the primary path; standalone is demoted to a clearly-marked subsection. (Original ask in #21.)
2. **Staleness sweep on the surrounding "how do I use this" sections** — the manual-run, Web Dashboard, Dashboard API, and Helm Chart Values blocks all lagged the actual capabilities the dashboard has grown in #14 / #18 / #25 / #30 / #32. Folded in while I was already there.

## 1 · Quick Start restructure (the #21 ask)

The old Quick Start opened with a one-line callout pointing at `examples/` and then spent the rest of the section on standalone `helm install` — the framing read "standalone first, operator second" even though operator-managed is the default in any NIC deployment.

**Before:**

```
## Quick Start
> Callout: "in NIC the operator handles this. The steps below are for standalone."
### Prerequisites (table — including "Nebari Operator CRDs: optional")
### Install (helm repo add + helm install)
### Verify
### Trigger a Manual Run
### View the Report
### Uninstall
```

**After:**

```
## Quick Start
[Lead paragraph — operator-managed is the default]

### Operator-managed install (default)
[kubectl apply examples/argocd-application.yaml — auto-stamped to the latest release]
[Short values block: nebariapp.enabled/hostname, webUI.enabled/features.timelineDeltas]
[Verify: kubectl get application + kubectl get cronjob + kubectl get pods]

### Standalone install (without the Nebari Operator)
> Use only on vanilla K8s without NIC.

#### Prerequisites (table)
#### Install / Verify / Trigger a manual run / View the report / Uninstall
```

- Operator path now references [`examples/argocd-application.yaml`](examples/argocd-application.yaml) directly — that file is auto-stamped to the released chart version on every tag via the workflow added in #28, so it always matches what `helm repo add nebari/...` resolves to.
- Prereqs table moved into the standalone subsection — those prereqs only apply when **you** run helm install, not when the operator does.
- Dropped the "Nebari Operator CRDs: optional" row. The CRDs aren't actually optional under operator-managed (they're assumed by the section), and under standalone they're a one-line callout pointing at `docs/nebariapp-crd-reference.md`.

## 2 · Staleness sweep (added during review)

While restructuring, the surrounding sections turned out to be lagging the dashboard's actual capabilities. Same single-file diff, so folded in here:

### `#### Trigger a manual run`
Now leads with the dashboard's Run Scan button as option 1 (admin-gated, hidden until `webUI.oidcIssuer` + `webUI.adminGroups` are set, automatic under `nebariapp.enabled: true`). `kubectl create job` stays as option 2 with a note about `webUI.manualJobTTL` behavior between the two paths.

### `## Web Dashboard` → "The dashboard provides"
Added three rows that have shipped over the last few PRs:

- **Run Scan** — admin-gated; triggers a one-shot Job from the CronJob template (#14)
- **Export** (`CSV` / `Markdown` / `JSON`) — downloads the selected report, not just the latest (#25)
- **Timeline delta badge** — `+N / -N` unique-image change between adjacent scans, opt-in via `webUI.features.timelineDeltas` (#32)

Also updated the stat-card description to "N / M ratios" matching the rendering after #30, and the image-table description to note the sticky header / truncated workload column from the same PR.

### `### Dashboard API` table
Added three endpoints that have existed but were missing from the docs:

- `GET /api/me` — calling user's identity + feature flags
- `GET /api/export?format=csv|markdown|md` — CSV / Markdown export, with `?filename=` to pin a historical report
- `POST /api/scan` — manual scan Job trigger (403/503 semantics noted)

### `## Helm Chart Values` sample
The `webUI` block now shows `oidcIssuer`, `adminGroups`, `manualJobTTL`, and `features.timelineDeltas` — the four values most operators actually touch on a standalone install. Operator-managed users get most of these wired automatically by the operator from `nebariapp.auth`.

## What's NOT in here

- **`docs/configuration.md`** is also out of date — it only documents collector env vars, not dashboard ones (`PROVENANCE_OIDC_ISSUER`, `PROVENANCE_ADMIN_GROUPS`, `PROVENANCE_MANUAL_JOB_TTL`, `PROVENANCE_FEATURE_TIMELINE_DELTAS`, etc.). Worth a separate follow-up PR scoped to that doc — bundling here would balloon the diff.

- Capability table (`## What It Does`) at the top of the README — unchanged. The dashboard / Grafana / export bits are already represented there; adding "manual scan trigger" as a top-level capability would be more noise than signal since it's a sub-feature of the dashboard row.

## Test plan

- [x] Render on GitHub after push and confirm the new section ordering is what was intended.
- [x] `examples/argocd-application.yaml` still exists; the `kubectl apply -f` snippet is the canonical entry point.
- [x] No CI dependencies — README-only diff.
- [ ] Visual review on the rendered PR by anyone who's used the dashboard recently (sanity-check the Web Dashboard feature list matches what they see in the UI).
