### PR TITLE
docs(readme): reorder for operator-first reader, refresh dashboard sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,37 +56,6 @@ audit submissions, or ad-hoc `jq`.
 It exists because answering *"what is actually running on this cluster, where did it come from, and is it signed?"*
 should not require manual auditing.
 
-## Architecture
-
-```mermaid
-flowchart TD
-    Cron[Kubernetes CronJob<br/>default: daily 06:00 UTC]
-    ImgDisc[Image Discovery<br/>pods + workload owners]
-    HelmDisc[Helm Discovery<br/>via Helm SDK]
-    Enrich[Enrichment<br/>digest resolve · cosign verify<br/>SBOM · SLSA · update check]
-    Report[(JSON Provenance Report)]
-    Dash[Web Dashboard<br/>+ JSON API · owns the PVC]
-    CM[(ConfigMap<br/>persistence.mode=configmap)]
-    PVC[(Shared PVC<br/>persistence.mode=pvc)]
-    Grafana[Grafana<br/>via Infinity datasource]
-
-    Cron --> ImgDisc
-    Cron --> HelmDisc
-    ImgDisc --> Enrich
-    Enrich --> Report
-    HelmDisc --> Report
-    Report -->|HTTP upload, default| Dash
-    Report -.-> CM
-    Report -.-> PVC
-    PVC -.-> Dash
-    Dash --> Grafana
-```
-
-The collector reads the Kubernetes API for inventory and the registry for enrichment, then ships the report to
-the dashboard's internal upload endpoint (default), a ConfigMap, or a shared PVC depending on `persistence.mode`
-(see [Storage modes](#storage-modes)). It does not push to remote services or mutate cluster state outside the
-configured sink.
-
 ## What It Does
 
 | Capability | Description |
@@ -131,6 +100,13 @@ webUI:
   features:
     timelineDeltas: false             # opt-in; show +N/-N badges between scans
 ```
+
+Setting `nebariapp.enabled: true` renders a `NebariApp` custom resource that registers the pack with the
+[Nebari Operator](https://github.com/nebari-dev/nebari-operator). The operator wires up routing, OIDC, and
+landing-page registration so the web dashboard is reachable through the Nebari gateway under
+`https://<hostname>` and surfaced on the [Nebari Landing page](https://github.com/nebari-dev/nebari-landing).
+Leave it `false` for clusters that aren't running the operator. Full field reference:
+[docs/nebariapp-crd-reference.md](docs/nebariapp-crd-reference.md).
 
 Verify:
 
@@ -455,15 +431,6 @@ nebariapp:
 
 See [examples/](examples/) for complete deployment examples (standalone, Nebari, ArgoCD).
 
-### Nebari integration
-
-Setting `nebariapp.enabled: true` renders a `NebariApp` custom resource that registers the pack with the
-[Nebari Operator](https://github.com/nebari-dev/nebari-operator). The operator wires up routing, OIDC, and
-landing-page registration so the web dashboard is reachable through the Nebari gateway under
-`https://<hostname>` and surfaced on the [Nebari Landing page](https://github.com/nebari-dev/nebari-landing).
-Leave it `false` for clusters that aren't running the operator. Full field reference:
-[docs/nebariapp-crd-reference.md](docs/nebariapp-crd-reference.md).
-
 ### Private registries
 
 When images are pulled from a private registry (e.g. Harbor, Artifactory, GHCR with a token), provide a
@@ -564,6 +531,37 @@ chart/                        Helm chart (CronJob + RBAC + Dashboard + NebariApp
 examples/                     Deployment examples (standalone, Nebari, ArgoCD)
 docs/                         Configuration, report schema, NebariApp CRD reference
 ```
+
+## Architecture
+
+```mermaid
+flowchart TD
+    Cron[Kubernetes CronJob<br/>default: daily 06:00 UTC]
+    ImgDisc[Image Discovery<br/>pods + workload owners]
+    HelmDisc[Helm Discovery<br/>via Helm SDK]
+    Enrich[Enrichment<br/>digest resolve · cosign verify<br/>SBOM · SLSA · update check]
+    Report[(JSON Provenance Report)]
+    Dash[Web Dashboard<br/>+ JSON API · owns the PVC]
+    CM[(ConfigMap<br/>persistence.mode=configmap)]
+    PVC[(Shared PVC<br/>persistence.mode=pvc)]
+    Grafana[Grafana<br/>via Infinity datasource]
+
+    Cron --> ImgDisc
+    Cron --> HelmDisc
+    ImgDisc --> Enrich
+    Enrich --> Report
+    HelmDisc --> Report
+    Report -->|HTTP upload, default| Dash
+    Report -.-> CM
+    Report -.-> PVC
+    PVC -.-> Dash
+    Dash --> Grafana
+```
+
+The collector reads the Kubernetes API for inventory and the registry for enrichment, then ships the report to
+the dashboard's internal upload endpoint (default), a ConfigMap, or a shared PVC depending on `persistence.mode`
+(see [Storage modes](#storage-modes)). It does not push to remote services or mutate cluster state outside the
+configured sink.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ audit submissions, or ad-hoc `jq`.
 It exists because answering *"what is actually running on this cluster, where did it come from, and is it signed?"*
 should not require manual auditing.
 
+> Curious how the pieces fit together? See the [architecture diagram](#architecture) further down.
+
 ## What It Does
 
 | Capability | Description |
@@ -118,9 +120,6 @@ kubectl get application provenance-collector -n argocd
 kubectl get cronjob -n provenance-system
 kubectl get pods -n provenance-system -l app.kubernetes.io/name=provenance-collector
 ```
-
-The operator wires routing (Envoy Gateway), OIDC (Keycloak), and surfaces the dashboard on the
-[Nebari Landing](https://github.com/nebari-dev/nebari-landing) page — no extra config needed beyond `hostname`.
 
 ### Standalone install (without the Nebari Operator)
 
@@ -428,8 +427,6 @@ webUI:
 nebariapp:
   enabled: false
 ```
-
-See [examples/](examples/) for complete deployment examples (standalone, Nebari, ArgoCD).
 
 ### Private registries
 


### PR DESCRIPTION
## Summary

README reordering pass that consolidates the work from #21 / #33 and rebalances the section flow for the dominant reader: someone evaluating or installing the pack, not someone reading reference material front-to-back.

This PR supersedes #33 (close it in favor of this one).

## Structural moves

### Architecture diagram → near the bottom

The `## Architecture` (mermaid) section now sits between `## Project Structure` and `## Contributing`, alongside the rest of the technical detail. Rationale: a reader who has already scrolled past install, dashboard, Grafana, configuration, report format, RBAC, and development is the audience for an architecture diagram; for evaluators landing at the top of the README, "what does it do" + "how do I install it" should come first.

To keep the diagram discoverable for curious readers up top, a small callout immediately after the "What is the Provenance Collector?" section links down to it:

> Curious how the pieces fit together? See the [architecture diagram](#architecture) further down.

The Architecture nav-bar link at the top of the README still exists (`Architecture · Quick Start · Web Dashboard · ...`).

### Quick Start → operator-managed first (closes #21)

The old Quick Start opened with a one-line callout pointing at `examples/` and then spent the rest of the section on `helm install` — read as "standalone first, operator second" even though operator-managed is the default in any NIC deployment.

**Before:**

```
## Quick Start
> Callout: "in NIC the operator handles this. The steps below are for standalone."
### Prerequisites (table — including "Nebari Operator CRDs: optional")
### Install (helm repo add + helm install)
### Verify / Trigger / View / Uninstall
```

**After:**

```
## Quick Start
[Lead paragraph — operator-managed is the default]

### Operator-managed install (default)
[kubectl apply examples/argocd-application.yaml — auto-stamped to the latest release]
[Short values block]
[Inline operator-wires-routing-OIDC paragraph]
[Verify]

### Standalone install (without the Nebari Operator)
> Use only on vanilla K8s without NIC.
#### Prerequisites (table)
#### Install / Verify / Trigger a manual run / View the report / Uninstall
```

- Operator path now references [`examples/argocd-application.yaml`](examples/argocd-application.yaml) directly — that file is auto-stamped to the released chart version on every tag (via #28), so it always matches what `helm repo add nebari/...` resolves to.
- Nebari-operator explanation hoisted from `## Helm Chart Values > ### Nebari integration` into the operator-managed install subsection — the explanation now lives next to where users actually need it (when they're deciding what to put in the Application manifest), not 200 lines later.
- Prereqs table moved into the standalone subsection — those prereqs only apply when **you** run helm install, not when the operator does.
- Dropped the "Nebari Operator CRDs: optional" row from the prereqs table. CRDs aren't actually optional under operator-managed (assumed by the section); under standalone they're a one-line callout pointing at `docs/nebariapp-crd-reference.md`.

### Manual-run section now leads with the dashboard button

`#### Trigger a manual run` (standalone subsection) now leads with the dashboard's Run Scan button as option 1 (admin-gated, hidden until `webUI.oidcIssuer` + `webUI.adminGroups` are set, automatic under `nebariapp.enabled: true`). `kubectl create job` stays as option 2 with a note about `webUI.manualJobTTL` behavior between the two paths.

## Capability refresh

While restructuring, the surrounding sections turned out to lag the dashboard's actual capabilities:

### `## Web Dashboard` → "The dashboard provides" list

Added three rows that have shipped over the last few PRs:

- **Run Scan** — admin-gated; triggers a one-shot Job from the CronJob template (#14)
- **Export** (`CSV` / `Markdown` / `JSON`) — downloads the selected report, not just the latest (#25)
- **Timeline delta badge** — `+N / -N` unique-image change between adjacent scans, opt-in via `webUI.features.timelineDeltas` (#32)

Also updated the stat-card description to "N / M ratios" matching the rendering after #30, and the image-table description to note the sticky header / truncated workload column from the same PR.

### `### Dashboard API` table

Added three endpoints that have existed but were missing from the docs:

- `GET /api/me` — calling user's identity + feature flags
- `GET /api/export?format=csv|markdown|md` — CSV / Markdown export, with `?filename=` to pin a historical report
- `POST /api/scan` — manual scan Job trigger (403 / 503 semantics noted)

### `## Helm Chart Values` sample

The `webUI` block now shows `oidcIssuer`, `adminGroups`, `manualJobTTL`, and `features.timelineDeltas` — the four values most operators actually touch on a standalone install. Operator-managed users get most of these wired automatically by the operator from `nebariapp.auth`.

## Polish from review

- One redundant single-line operator paragraph after the Verify block deleted — the full explanation lives one block above it.
- Orphaned "See `examples/` for complete deployment examples" sentence between the chart-values block and `### Private registries` deleted — the operator-managed install already references `examples/argocd-application.yaml`, and the Examples nav link covers the directory.

## What's NOT in here

**`docs/configuration.md` drift** — the doc only lists collector env vars; the dashboard's auth / scan / feature-flag env vars are missing. This is a structural problem that'll keep happening every time a new env var lands. Filing a separate issue to track auto-generating that doc from the Go config struct (or chart values) so it stops diverging from reality. Out of scope here.

## Test plan

- [x] Render on GitHub after push and confirm the new section ordering / cross-link is what was intended.
- [x] `examples/argocd-application.yaml` still exists; the `kubectl apply -f` snippet is the canonical entry point.
- [x] No CI dependencies — README-only diff.
- [ ] Visual review on the rendered PR by anyone who's used the dashboard recently (sanity-check the Web Dashboard feature list matches what they see in the UI).
