### PR TITLE
ci(docs): generate configuration.md from a single source of truth

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,6 +23,17 @@ jobs:
         env:
           GOTOOLCHAIN: auto
 
+      # configspec drift guards. checkenvs fails if any os.Getenv (or a name
+      # passed to one of the config helpers) references a PROVENANCE_* /
+      # KUBECONFIG name that isn't in internal/configspec.Vars. gendocs --check
+      # fails if docs/configuration.md is stale relative to the spec. Together
+      # they keep the docs and the code from drifting.
+      - name: Verify configspec coverage
+        run: go run ./hack/checkenvs
+
+      - name: Verify docs/configuration.md is up to date
+        run: go run ./hack/gendocs --check
+
   helm-lint:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TAG     ?= $(VERSION)
 
 LDFLAGS := -s -w -X github.com/nebari-dev/provenance-collector/internal/report.Version=$(VERSION)
 
-.PHONY: build test lint docker-build docker-push helm-lint clean
+.PHONY: build test lint docs docs-check checkenvs docker-build docker-push helm-lint clean
 
 build:
 	CGO_ENABLED=0 go build -ldflags="$(LDFLAGS)" -o bin/provenance-collector ./cmd/provenance-collector
@@ -16,6 +16,20 @@ test:
 lint:
 	golangci-lint run ./...
 	helm lint chart/
+
+# Regenerate docs/configuration.md from internal/configspec/spec.go.
+docs:
+	go run ./hack/gendocs
+
+# CI guard: fail if docs/configuration.md is stale relative to the spec OR
+# if a source file references an env var not present in the spec.
+docs-check: checkenvs
+	go run ./hack/gendocs --check
+
+# Static check that every os.Getenv("...") in cmd/ and internal/ refers to a
+# name listed in internal/configspec/spec.go.
+checkenvs:
+	go run ./hack/checkenvs
 
 docker-build:
 	docker build --build-arg VERSION=$(VERSION) -t $(IMAGE):$(TAG) .

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,67 +1,88 @@
 # Configuration Reference
 
-The provenance collector is configured entirely via environment variables.
-When deployed with the Helm chart, these are set through `values.yaml` and
-injected via a ConfigMap.
+<!-- GENERATED FILE — do not edit by hand.
+     Source of truth: internal/configspec/spec.go.
+     Regenerate with: make docs (or: go run ./hack/gendocs)
+     CI guards drift between this file and the spec. -->
 
-## Environment Variables
+> **Generated** from `internal/configspec/spec.go`. Edit the spec and run `make docs` to update this file.
 
-### Namespace Filtering
+The collector and dashboard binaries are configured entirely via environment
+variables. When deployed with the Helm chart, these are set through
+`values.yaml` and rendered into the relevant pod's env block.
+
+## Collector
+
+Read by `cmd/provenance-collector` (the CronJob).
 
 | Variable | Type | Default | Description |
 |---|---|---|---|
-| `PROVENANCE_NAMESPACES` | comma-separated | *(all)* | Namespaces to scan. Empty means all namespaces. |
-| `PROVENANCE_EXCLUDE_NAMESPACES` | comma-separated | *(none)* | Namespaces to exclude from scanning. |
-
-### Registry
-
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `PROVENANCE_REGISTRY_AUTH` | path | *(empty)* | Path to Docker `config.json` for private registry authentication. |
+| `PROVENANCE_NAMESPACES` | string list | *(empty)* | Comma-separated namespaces to scan. Empty means scan all namespaces. |
+| `PROVENANCE_EXCLUDE_NAMESPACES` | string list | *(empty)* | Comma-separated namespaces to exclude from the scan. |
+| `PROVENANCE_REGISTRY_AUTH` | string | *(empty)* | Path to a Docker `config.json` for private registry authentication. |
 | `PROVENANCE_REGISTRY_TIMEOUT` | duration | `30s` | Timeout for registry operations (digest resolution, tag listing). |
 | `PROVENANCE_CHECK_UPDATES` | bool | `true` | Check registries for newer semver tags. |
-
-### Signature Verification
-
-| Variable | Type | Default | Description |
-|---|---|---|---|
+| `PROVENANCE_UPDATE_LEVEL` | string | `patch` | Minimum version bump to flag as an update: `patch`, `minor`, or `major`. |
+| `PROVENANCE_SKIP_PRERELEASE` | bool | `true` | Ignore alpha / beta / RC versions when checking for updates. |
 | `PROVENANCE_VERIFY_SIGNATURES` | bool | `true` | Check for cosign signatures on images. |
-| `PROVENANCE_COSIGN_PUBLIC_KEY` | string | *(empty)* | Path or KMS URI for cosign public key. Empty = existence check only (no trust chain verification). |
-
-### Helm
-
-| Variable | Type | Default | Description |
-|---|---|---|---|
+| `PROVENANCE_COSIGN_PUBLIC_KEY` | string | *(empty)* | Path or KMS URI for the cosign public key. Empty = existence check only, no trust-chain verification. |
+| `PROVENANCE_CHECK_SBOM` | bool | `true` | Check for SBOM attestations on discovered images. |
+| `PROVENANCE_CHECK_PROVENANCE` | bool | `true` | Check for SLSA provenance attestations on discovered images. |
 | `PROVENANCE_HELM_ENABLED` | bool | `true` | Discover deployed Helm releases. |
-
-### Report Output
-
-| Variable | Type | Default | Description |
-|---|---|---|---|
-| `PROVENANCE_REPORT_OUTPUT` | string | `pvc` | Output type: `pvc` (filesystem) or `configmap`. |
-| `PROVENANCE_REPORT_PATH` | path | `/reports` | Directory for PVC-based reports. |
-| `PROVENANCE_REPORT_CONFIGMAP` | string | `provenance-report` | ConfigMap name for configmap-based output. |
-| `PROVENANCE_REPORT_CONFIGMAP_NAMESPACE` | string | *(release namespace)* | Namespace for ConfigMap output. |
-
-### Metadata
-
-| Variable | Type | Default | Description |
-|---|---|---|---|
+| `PROVENANCE_REPORT_OUTPUT` | string | `http` | Report output type: `http` (POST to the dashboard's internal endpoint), `pvc` (write to a shared PVC), or `configmap`. |
+| `PROVENANCE_REPORT_CONFIGMAP` | string | `provenance-report` | ConfigMap name used by the `configmap` report output type. |
+| `PROVENANCE_REPORT_CONFIGMAP_NAMESPACE` | string | `default` | Namespace for the report ConfigMap. Typically overridden by the chart to the release namespace. |
+| `PROVENANCE_REPORT_UPLOAD_URL` | string | *(set by chart)* | Full URL the collector POSTs to in `http` mode, e.g. `http://provenance-collector-web-internal.<ns>.svc:8081/internal/reports`. |
+| `PROVENANCE_REPORT_UPLOAD_TIMEOUT` | duration | `30s` | Timeout for the report upload request in `http` mode. |
 | `PROVENANCE_CLUSTER_NAME` | string | *(empty)* | Cluster name included in report metadata. Informational only. |
+| `KUBECONFIG` | string | *(empty)* | Path to a kubeconfig file. Empty = use in-cluster credentials (the normal case for the chart-deployed CronJob). |
 
-### Kubernetes
+## Shared
+
+Read by both binaries.
 
 | Variable | Type | Default | Description |
 |---|---|---|---|
-| `KUBECONFIG` | path | *(empty)* | Path to kubeconfig file. Empty = use in-cluster credentials. |
+| `PROVENANCE_REPORT_PATH` | string | `/reports` | Filesystem path used by the dashboard pod (always) and the collector pod (only in `pvc` mode). |
+| `PROVENANCE_REPORT_RETENTION` | duration | `168h` | Auto-prune reports older than this. Use `-1` to disable cleanup and keep all reports. |
 
-## Duration Format
+## Dashboard
+
+Read by `cmd/dashboard` (the web UI pod).
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `PROVENANCE_DASHBOARD_ADDR` | string | `:8080` | Listen address for the public HTTP server (UI + read API). |
+| `PROVENANCE_DASHBOARD_INTERNAL_ADDR` | string | `:8081` | Listen address for the internal upload endpoint. Never put this behind an Ingress. |
+| `PROVENANCE_UPLOAD_MAX_BYTES` | bytes | `16777216` | Max body size in bytes accepted on the internal upload endpoint. Default ~16 MiB. |
+| `PROVENANCE_OIDC_ISSUER` | string | *(empty)* | OIDC issuer URL the dashboard calls for userinfo (e.g. `https://keycloak.example.com/realms/nebari`). Empty = auth disabled. |
+| `PROVENANCE_ADMIN_GROUPS` | string list | *(empty)* | Comma-separated OIDC groups whose members may trigger a scan via the dashboard's Run Scan button. |
+| `PROVENANCE_MANUAL_JOB_TTL` | duration | `1h` | TTL after which dashboard-triggered Jobs are auto-cleaned. `0` (or any zero-duration string) keeps Jobs forever. |
+| `PROVENANCE_NAMESPACE` | string | *(set by chart)* | Namespace the dashboard runs in. Used to address the CronJob from `/api/scan`. The chart populates this via the downward API. |
+| `PROVENANCE_CRONJOB_NAME` | string | *(set by chart)* | Name of the CronJob the dashboard creates manual Jobs from. The chart sets this to the release's full name. |
+| `PROVENANCE_FEATURE_TIMELINE_DELTAS` | bool | `false` | Opt-in: render a `+N / -N` unique-image delta badge on each timeline card vs the previous scan. Exposed in the chart as `webUI.features.timelineDeltas`. |
+
+## Value formats
+
+### Duration
 
 Duration values use Go's `time.ParseDuration` format:
+
 - `30s` — 30 seconds
 - `5m` — 5 minutes
 - `1h30m` — 1 hour 30 minutes
+- `168h` — 7 days
 
-## Boolean Values
+Where noted, `-1` disables the timeout / retention.
 
-Boolean values accept: `true`, `1` (truthy) or anything else (falsy).
+### Boolean
+
+Boolean values accept `true` / `1` / `yes` / `on` (case-insensitive) as truthy. Anything else, including unset, is false.
+
+### Bytes
+
+Integer count of bytes (decimal). `16777216` is 16 MiB.
+
+### String list
+
+Comma-separated. Whitespace around commas is trimmed; empty entries are dropped.

--- a/hack/checkenvs/main.go
+++ b/hack/checkenvs/main.go
@@ -1,0 +1,121 @@
+// checkenvs is a static guard against env-var drift.
+//
+// It scans every .go file under cmd/ and internal/ for string literals that
+// look like an env-var name this project might read (`PROVENANCE_*` or the
+// well-known `KUBECONFIG`) and fails if any of those names isn't present in
+// internal/configspec.Vars.
+//
+// We walk the AST rather than greping `os.Getenv("...")` because the
+// collector reads env vars through helper functions (`envDefault`,
+// `envBool`, `envDuration`) that take the name as a *parameter* — so the
+// string literal sits at the call site, not inside `os.Getenv`. Comments
+// and other non-string tokens are naturally excluded by parsing.
+//
+// The point isn't to forbid os.Getenv — it's to keep the spec the single
+// source of truth for "what env vars does this project read". Adding a new
+// env var means: add it to internal/configspec/spec.go, then read it in
+// code. Forgetting the spec entry trips this check.
+//
+// Usage:
+//
+//	go run ./hack/checkenvs
+//
+// Exits 0 if everything reads through known names, 1 otherwise.
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/nebari-dev/provenance-collector/internal/configspec"
+)
+
+// envNamePattern is what an env-var name from this project looks like — a
+// PROVENANCE_* identifier or the well-known KUBECONFIG. Anchored so we don't
+// match substrings.
+var envNamePattern = regexp.MustCompile(`^(PROVENANCE_[A-Z0-9_]+|KUBECONFIG)$`)
+
+// Directories to scan. We deliberately exclude hack/ — the spec is in
+// internal/configspec but the tooling under hack/ doesn't read env vars
+// directly (gendocs reads the spec; checkenvs is what you're reading).
+var scanDirs = []string{"cmd", "internal"}
+
+func main() {
+	found, err := scanForEnvNames()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "checkenvs:", err)
+		os.Exit(2)
+	}
+
+	spec := map[string]bool{}
+	for _, v := range configspec.Vars {
+		spec[v.Name] = true
+	}
+
+	var unknown []string
+	for name := range found {
+		if !spec[name] {
+			unknown = append(unknown, name)
+		}
+	}
+	sort.Strings(unknown)
+
+	if len(unknown) > 0 {
+		fmt.Fprintln(os.Stderr, "Env vars referenced in source but missing from internal/configspec.Vars:")
+		for _, n := range unknown {
+			fmt.Fprintln(os.Stderr, "  -", n)
+		}
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "Add each one to internal/configspec/spec.go with its Scope / Kind / Default / Description,")
+		fmt.Fprintln(os.Stderr, "then run `make docs` to regenerate docs/configuration.md.")
+		os.Exit(1)
+	}
+
+	fmt.Printf("checkenvs: %d env-var name(s) referenced in source, all covered by spec.\n", len(found))
+}
+
+func scanForEnvNames() (map[string]struct{}, error) {
+	found := map[string]struct{}{}
+	fset := token.NewFileSet()
+	for _, dir := range scanDirs {
+		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+			if err != nil {
+				return fmt.Errorf("parse %s: %w", path, err)
+			}
+			ast.Inspect(file, func(n ast.Node) bool {
+				lit, ok := n.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return true
+				}
+				// BasicLit.Value includes the surrounding quotes; trim them.
+				val := strings.Trim(lit.Value, "`\"")
+				if envNamePattern.MatchString(val) {
+					found[val] = struct{}{}
+				}
+				return true
+			})
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return found, nil
+}

--- a/hack/gendocs/main.go
+++ b/hack/gendocs/main.go
@@ -1,0 +1,155 @@
+// gendocs renders docs/configuration.md from internal/configspec.Vars.
+//
+// Usage:
+//
+//	go run ./hack/gendocs           # write docs/configuration.md
+//	go run ./hack/gendocs --check   # exit 1 if the file on disk is stale
+//
+// `--check` exists so CI can fail a PR that touches the spec but doesn't
+// commit the regenerated doc (and vice versa).
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"text/template"
+
+	"github.com/nebari-dev/provenance-collector/internal/configspec"
+)
+
+const outputPath = "docs/configuration.md"
+
+var docTemplate = template.Must(template.New("doc").Funcs(template.FuncMap{
+	"defaultCell": func(d string) string {
+		if d == "" {
+			return "*(empty)*"
+		}
+		// Render parenthesised placeholders (e.g. "(set by chart)") as plain
+		// italics so they read as commentary, not as a literal value.
+		if d != "" && d[0] == '(' && d[len(d)-1] == ')' {
+			return "*" + d + "*"
+		}
+		return "`" + d + "`"
+	},
+}).Parse(`# Configuration Reference
+
+<!-- GENERATED FILE — do not edit by hand.
+     Source of truth: internal/configspec/spec.go.
+     Regenerate with: make docs (or: go run ./hack/gendocs)
+     CI guards drift between this file and the spec. -->
+
+> **Generated** from ` + "`internal/configspec/spec.go`" + `. Edit the spec and run ` + "`make docs`" + ` to update this file.
+
+The collector and dashboard binaries are configured entirely via environment
+variables. When deployed with the Helm chart, these are set through
+` + "`values.yaml`" + ` and rendered into the relevant pod's env block.
+
+## Collector
+
+Read by ` + "`cmd/provenance-collector`" + ` (the CronJob).
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+{{- range .Collector }}
+| ` + "`{{ .Name }}`" + ` | {{ .Kind }} | {{ defaultCell .Default }} | {{ .Description }} |
+{{- end }}
+
+## Shared
+
+Read by both binaries.
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+{{- range .Shared }}
+| ` + "`{{ .Name }}`" + ` | {{ .Kind }} | {{ defaultCell .Default }} | {{ .Description }} |
+{{- end }}
+
+## Dashboard
+
+Read by ` + "`cmd/dashboard`" + ` (the web UI pod).
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+{{- range .Dashboard }}
+| ` + "`{{ .Name }}`" + ` | {{ .Kind }} | {{ defaultCell .Default }} | {{ .Description }} |
+{{- end }}
+
+## Value formats
+
+### Duration
+
+Duration values use Go's ` + "`time.ParseDuration`" + ` format:
+
+- ` + "`30s`" + ` — 30 seconds
+- ` + "`5m`" + ` — 5 minutes
+- ` + "`1h30m`" + ` — 1 hour 30 minutes
+- ` + "`168h`" + ` — 7 days
+
+Where noted, ` + "`-1`" + ` disables the timeout / retention.
+
+### Boolean
+
+Boolean values accept ` + "`true`" + ` / ` + "`1`" + ` / ` + "`yes`" + ` / ` + "`on`" + ` (case-insensitive) as truthy. Anything else, including unset, is false.
+
+### Bytes
+
+Integer count of bytes (decimal). ` + "`16777216`" + ` is 16 MiB.
+
+### String list
+
+Comma-separated. Whitespace around commas is trimmed; empty entries are dropped.
+`))
+
+func main() {
+	check := flag.Bool("check", false, "exit 1 if the generated output differs from the file on disk")
+	flag.Parse()
+
+	var collector, shared, dashboard []configspec.Var
+	for _, v := range configspec.Vars {
+		switch v.Scope {
+		case configspec.ScopeCollector:
+			collector = append(collector, v)
+		case configspec.ScopeShared:
+			shared = append(shared, v)
+		case configspec.ScopeDashboard:
+			dashboard = append(dashboard, v)
+		default:
+			fmt.Fprintf(os.Stderr, "gendocs: var %q has unknown scope %q\n", v.Name, v.Scope)
+			os.Exit(2)
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := docTemplate.Execute(&buf, map[string]any{
+		"Collector": collector,
+		"Shared":    shared,
+		"Dashboard": dashboard,
+	}); err != nil {
+		fmt.Fprintln(os.Stderr, "gendocs: render failed:", err)
+		os.Exit(2)
+	}
+
+	want := buf.Bytes()
+
+	if *check {
+		got, err := os.ReadFile(outputPath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "gendocs --check:", err)
+			os.Exit(1)
+		}
+		if !bytes.Equal(got, want) {
+			fmt.Fprintf(os.Stderr, "gendocs --check: %s is stale relative to internal/configspec/spec.go.\n", outputPath)
+			fmt.Fprintln(os.Stderr, "Run `make docs` (or `go run ./hack/gendocs`) and commit the result.")
+			os.Exit(1)
+		}
+		return
+	}
+
+	if err := os.WriteFile(outputPath, want, 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, "gendocs: write failed:", err)
+		os.Exit(2)
+	}
+	fmt.Printf("gendocs: wrote %s (%d entries)\n", outputPath, len(configspec.Vars))
+}

--- a/internal/configspec/spec.go
+++ b/internal/configspec/spec.go
@@ -1,0 +1,321 @@
+// Package configspec is the single source of truth for the env vars the
+// collector and dashboard binaries read at startup.
+//
+// Adding or renaming an env var means editing this file. The doc generator
+// (hack/gendocs) renders docs/configuration.md from Vars, and the static
+// check (hack/checkenvs) fails the build if any os.Getenv call under cmd/
+// or internal/ refers to a name not present here. Together those two keep
+// the docs and the code from drifting apart again.
+//
+// This package only describes the env vars; the actual parsing still lives
+// in internal/config and cmd/dashboard. A future refactor can bind those
+// parsers through Vars too (see issue #35), but the immediate goal is just
+// to stop the documentation bleed.
+package configspec
+
+// Scope captures which binary reads a given env var. "shared" means both.
+type Scope string
+
+const (
+	ScopeCollector Scope = "collector"
+	ScopeDashboard Scope = "dashboard"
+	ScopeShared    Scope = "shared"
+)
+
+// Kind describes the type the env var's string value is parsed into. The
+// generator uses it for the "Type" column; the parsers in main.go choose
+// the right conversion routine themselves.
+type Kind string
+
+const (
+	KindString     Kind = "string"
+	KindBool       Kind = "bool"
+	KindDuration   Kind = "duration"
+	KindBytes      Kind = "bytes"
+	KindStringList Kind = "string list"
+)
+
+// Var is one env-var entry.
+type Var struct {
+	Name        string
+	Scope       Scope
+	Kind        Kind
+	Default     string // human-readable; "" means render as "(empty)"
+	Description string
+}
+
+// Vars is the canonical list. Order within a scope matters for the generated
+// doc — keep logically related vars adjacent.
+var Vars = []Var{
+	// ----------------------------------------------------------------
+	// Collector — what to scan
+	// ----------------------------------------------------------------
+	{
+		Name:        "PROVENANCE_NAMESPACES",
+		Scope:       ScopeCollector,
+		Kind:        KindStringList,
+		Default:     "",
+		Description: "Comma-separated namespaces to scan. Empty means scan all namespaces.",
+	},
+	{
+		Name:        "PROVENANCE_EXCLUDE_NAMESPACES",
+		Scope:       ScopeCollector,
+		Kind:        KindStringList,
+		Default:     "",
+		Description: "Comma-separated namespaces to exclude from the scan.",
+	},
+
+	// ----------------------------------------------------------------
+	// Collector — registry + update checks
+	// ----------------------------------------------------------------
+	{
+		Name:        "PROVENANCE_REGISTRY_AUTH",
+		Scope:       ScopeCollector,
+		Kind:        KindString,
+		Default:     "",
+		Description: "Path to a Docker `config.json` for private registry authentication.",
+	},
+	{
+		Name:        "PROVENANCE_REGISTRY_TIMEOUT",
+		Scope:       ScopeCollector,
+		Kind:        KindDuration,
+		Default:     "30s",
+		Description: "Timeout for registry operations (digest resolution, tag listing).",
+	},
+	{
+		Name:        "PROVENANCE_CHECK_UPDATES",
+		Scope:       ScopeCollector,
+		Kind:        KindBool,
+		Default:     "true",
+		Description: "Check registries for newer semver tags.",
+	},
+	{
+		Name:        "PROVENANCE_UPDATE_LEVEL",
+		Scope:       ScopeCollector,
+		Kind:        KindString,
+		Default:     "patch",
+		Description: "Minimum version bump to flag as an update: `patch`, `minor`, or `major`.",
+	},
+	{
+		Name:        "PROVENANCE_SKIP_PRERELEASE",
+		Scope:       ScopeCollector,
+		Kind:        KindBool,
+		Default:     "true",
+		Description: "Ignore alpha / beta / RC versions when checking for updates.",
+	},
+
+	// ----------------------------------------------------------------
+	// Collector — supply-chain checks
+	// ----------------------------------------------------------------
+	{
+		Name:        "PROVENANCE_VERIFY_SIGNATURES",
+		Scope:       ScopeCollector,
+		Kind:        KindBool,
+		Default:     "true",
+		Description: "Check for cosign signatures on images.",
+	},
+	{
+		Name:        "PROVENANCE_COSIGN_PUBLIC_KEY",
+		Scope:       ScopeCollector,
+		Kind:        KindString,
+		Default:     "",
+		Description: "Path or KMS URI for the cosign public key. Empty = existence check only, no trust-chain verification.",
+	},
+	{
+		Name:        "PROVENANCE_CHECK_SBOM",
+		Scope:       ScopeCollector,
+		Kind:        KindBool,
+		Default:     "true",
+		Description: "Check for SBOM attestations on discovered images.",
+	},
+	{
+		Name:        "PROVENANCE_CHECK_PROVENANCE",
+		Scope:       ScopeCollector,
+		Kind:        KindBool,
+		Default:     "true",
+		Description: "Check for SLSA provenance attestations on discovered images.",
+	},
+	{
+		Name:        "PROVENANCE_HELM_ENABLED",
+		Scope:       ScopeCollector,
+		Kind:        KindBool,
+		Default:     "true",
+		Description: "Discover deployed Helm releases.",
+	},
+
+	// ----------------------------------------------------------------
+	// Collector — report sink
+	// ----------------------------------------------------------------
+	{
+		Name:        "PROVENANCE_REPORT_OUTPUT",
+		Scope:       ScopeCollector,
+		Kind:        KindString,
+		Default:     "http",
+		Description: "Report output type: `http` (POST to the dashboard's internal endpoint), `pvc` (write to a shared PVC), or `configmap`.",
+	},
+	{
+		Name:        "PROVENANCE_REPORT_CONFIGMAP",
+		Scope:       ScopeCollector,
+		Kind:        KindString,
+		Default:     "provenance-report",
+		Description: "ConfigMap name used by the `configmap` report output type.",
+	},
+	{
+		Name:        "PROVENANCE_REPORT_CONFIGMAP_NAMESPACE",
+		Scope:       ScopeCollector,
+		Kind:        KindString,
+		Default:     "default",
+		Description: "Namespace for the report ConfigMap. Typically overridden by the chart to the release namespace.",
+	},
+	{
+		Name:        "PROVENANCE_REPORT_UPLOAD_URL",
+		Scope:       ScopeCollector,
+		Kind:        KindString,
+		Default:     "(set by chart)",
+		Description: "Full URL the collector POSTs to in `http` mode, e.g. `http://provenance-collector-web-internal.<ns>.svc:8081/internal/reports`.",
+	},
+	{
+		Name:        "PROVENANCE_REPORT_UPLOAD_TIMEOUT",
+		Scope:       ScopeCollector,
+		Kind:        KindDuration,
+		Default:     "30s",
+		Description: "Timeout for the report upload request in `http` mode.",
+	},
+
+	// ----------------------------------------------------------------
+	// Collector — metadata + Kubernetes
+	// ----------------------------------------------------------------
+	{
+		Name:        "PROVENANCE_CLUSTER_NAME",
+		Scope:       ScopeCollector,
+		Kind:        KindString,
+		Default:     "",
+		Description: "Cluster name included in report metadata. Informational only.",
+	},
+	{
+		Name:        "KUBECONFIG",
+		Scope:       ScopeCollector,
+		Kind:        KindString,
+		Default:     "",
+		Description: "Path to a kubeconfig file. Empty = use in-cluster credentials (the normal case for the chart-deployed CronJob).",
+	},
+
+	// ----------------------------------------------------------------
+	// Shared — read by both the collector and the dashboard
+	// ----------------------------------------------------------------
+	{
+		Name:        "PROVENANCE_REPORT_PATH",
+		Scope:       ScopeShared,
+		Kind:        KindString,
+		Default:     "/reports",
+		Description: "Filesystem path used by the dashboard pod (always) and the collector pod (only in `pvc` mode).",
+	},
+	{
+		Name:        "PROVENANCE_REPORT_RETENTION",
+		Scope:       ScopeShared,
+		Kind:        KindDuration,
+		Default:     "168h",
+		Description: "Auto-prune reports older than this. Use `-1` to disable cleanup and keep all reports.",
+	},
+
+	// ----------------------------------------------------------------
+	// Dashboard — server addresses
+	// ----------------------------------------------------------------
+	{
+		Name:        "PROVENANCE_DASHBOARD_ADDR",
+		Scope:       ScopeDashboard,
+		Kind:        KindString,
+		Default:     ":8080",
+		Description: "Listen address for the public HTTP server (UI + read API).",
+	},
+	{
+		Name:        "PROVENANCE_DASHBOARD_INTERNAL_ADDR",
+		Scope:       ScopeDashboard,
+		Kind:        KindString,
+		Default:     ":8081",
+		Description: "Listen address for the internal upload endpoint. Never put this behind an Ingress.",
+	},
+	{
+		Name:        "PROVENANCE_UPLOAD_MAX_BYTES",
+		Scope:       ScopeDashboard,
+		Kind:        KindBytes,
+		Default:     "16777216",
+		Description: "Max body size in bytes accepted on the internal upload endpoint. Default ~16 MiB.",
+	},
+
+	// ----------------------------------------------------------------
+	// Dashboard — auth (Run Scan button + /api/me)
+	// ----------------------------------------------------------------
+	{
+		Name:        "PROVENANCE_OIDC_ISSUER",
+		Scope:       ScopeDashboard,
+		Kind:        KindString,
+		Default:     "",
+		Description: "OIDC issuer URL the dashboard calls for userinfo (e.g. `https://keycloak.example.com/realms/nebari`). Empty = auth disabled.",
+	},
+	{
+		Name:        "PROVENANCE_ADMIN_GROUPS",
+		Scope:       ScopeDashboard,
+		Kind:        KindStringList,
+		Default:     "",
+		Description: "Comma-separated OIDC groups whose members may trigger a scan via the dashboard's Run Scan button.",
+	},
+	{
+		Name:        "PROVENANCE_MANUAL_JOB_TTL",
+		Scope:       ScopeDashboard,
+		Kind:        KindDuration,
+		Default:     "1h",
+		Description: "TTL after which dashboard-triggered Jobs are auto-cleaned. `0` (or any zero-duration string) keeps Jobs forever.",
+	},
+
+	// ----------------------------------------------------------------
+	// Dashboard — scan endpoint wiring
+	// ----------------------------------------------------------------
+	{
+		Name:        "PROVENANCE_NAMESPACE",
+		Scope:       ScopeDashboard,
+		Kind:        KindString,
+		Default:     "(set by chart)",
+		Description: "Namespace the dashboard runs in. Used to address the CronJob from `/api/scan`. The chart populates this via the downward API.",
+	},
+	{
+		Name:        "PROVENANCE_CRONJOB_NAME",
+		Scope:       ScopeDashboard,
+		Kind:        KindString,
+		Default:     "(set by chart)",
+		Description: "Name of the CronJob the dashboard creates manual Jobs from. The chart sets this to the release's full name.",
+	},
+
+	// ----------------------------------------------------------------
+	// Dashboard — feature flags
+	// ----------------------------------------------------------------
+	{
+		Name:        "PROVENANCE_FEATURE_TIMELINE_DELTAS",
+		Scope:       ScopeDashboard,
+		Kind:        KindBool,
+		Default:     "false",
+		Description: "Opt-in: render a `+N / -N` unique-image delta badge on each timeline card vs the previous scan. Exposed in the chart as `webUI.features.timelineDeltas`.",
+	},
+}
+
+// ByName looks up an entry by env-var name. Returns false if the name is not
+// in Vars — the static check uses this to find references in source that
+// haven't been added to the spec yet.
+func ByName(name string) (Var, bool) {
+	for _, v := range Vars {
+		if v.Name == name {
+			return v, true
+		}
+	}
+	return Var{}, false
+}
+
+// Names returns every env-var name in Vars, in declaration order. Convenience
+// for the static checker.
+func Names() []string {
+	out := make([]string, 0, len(Vars))
+	for _, v := range Vars {
+		out = append(out, v.Name)
+	}
+	return out
+}

--- a/internal/configspec/spec_test.go
+++ b/internal/configspec/spec_test.go
@@ -1,0 +1,59 @@
+package configspec
+
+import "testing"
+
+// TestVarsAreWellFormed catches the four mistakes you'd plausibly make
+// editing Vars by hand: duplicate names, empty names, unknown scope, or
+// unknown kind. Each one would produce a wrong-but-not-obviously-broken
+// configuration.md without this guard.
+func TestVarsAreWellFormed(t *testing.T) {
+	validScopes := map[Scope]bool{
+		ScopeCollector: true,
+		ScopeDashboard: true,
+		ScopeShared:    true,
+	}
+	validKinds := map[Kind]bool{
+		KindString:     true,
+		KindBool:       true,
+		KindDuration:   true,
+		KindBytes:      true,
+		KindStringList: true,
+	}
+
+	seen := make(map[string]int, len(Vars))
+	for i, v := range Vars {
+		if v.Name == "" {
+			t.Errorf("Vars[%d]: empty Name", i)
+		}
+		if prev, ok := seen[v.Name]; ok {
+			t.Errorf("Vars[%d] (%q): duplicate Name, first seen at index %d", i, v.Name, prev)
+		}
+		seen[v.Name] = i
+		if !validScopes[v.Scope] {
+			t.Errorf("Vars[%d] (%q): unknown Scope %q", i, v.Name, v.Scope)
+		}
+		if !validKinds[v.Kind] {
+			t.Errorf("Vars[%d] (%q): unknown Kind %q", i, v.Name, v.Kind)
+		}
+		if v.Description == "" {
+			t.Errorf("Vars[%d] (%q): empty Description", i, v.Name)
+		}
+	}
+}
+
+func TestByNameRoundTrip(t *testing.T) {
+	for _, want := range Vars {
+		got, ok := ByName(want.Name)
+		if !ok {
+			t.Errorf("ByName(%q) returned !ok for a var that's in Vars", want.Name)
+			continue
+		}
+		if got.Name != want.Name {
+			t.Errorf("ByName(%q).Name = %q", want.Name, got.Name)
+		}
+	}
+
+	if _, ok := ByName("PROVENANCE_NOT_A_REAL_VAR"); ok {
+		t.Error("ByName returned ok for a name not in Vars")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #35. Stops `docs/configuration.md` drift at the structural level: a single source of truth in `internal/configspec/spec.go`, a generator that renders the markdown from it, and a CI guard that fails the build if either the doc is stale or a source file references an env var not in the spec.

Before this PR, **16 of the 30 env vars the binaries actually read were undocumented** — including `PROVENANCE_OIDC_ISSUER`, `PROVENANCE_ADMIN_GROUPS`, `PROVENANCE_MANUAL_JOB_TTL`, and `PROVENANCE_FEATURE_TIMELINE_DELTAS`. That gap was created by hand-maintained docs lagging the code; this PR makes it impossible for that pattern to repeat.

## Scope

This is **Phase 1 only** (the recommended scope from the issue): single source of truth for *names + descriptions*, generated doc, drift guards. **Phase 2** (refactoring `cmd/dashboard/main.go` and `internal/config` to bind env-var parsing through the spec too) is deferred — that's a typed-config shape decision that deserves its own discussion. The structural drift guard here solves the immediate documentation problem on its own.

## What's added

### `internal/configspec/spec.go`
The canonical list. One `Var` entry per env var:

```go
type Var struct {
    Name        string
    Scope       Scope  // Collector | Dashboard | Shared
    Kind        Kind   // String | Bool | Duration | Bytes | StringList
    Default     string
    Description string
}

var Vars = []Var{
    {Name: "PROVENANCE_NAMESPACES", Scope: ScopeCollector, Kind: KindStringList, Default: "", Description: "..."},
    {Name: "PROVENANCE_OIDC_ISSUER", Scope: ScopeDashboard, Kind: KindString, Default: "", Description: "..."},
    ...
}
```

30 entries total across the three scopes.

### `hack/gendocs/main.go`
Renders `docs/configuration.md` from `configspec.Vars`. Grouped by scope (Collector / Shared / Dashboard) with a value-format appendix (duration / boolean / bytes / string-list semantics). Output banner makes the generated origin obvious to readers.

```bash
go run ./hack/gendocs           # write docs/configuration.md
go run ./hack/gendocs --check   # exit 1 if disk is stale vs spec
```

### `hack/checkenvs/main.go`
AST-based static guard. Walks every `.go` file under `cmd/` and `internal/`, finds every string literal matching the env-var name pattern (`PROVENANCE_*` or `KUBECONFIG`), and fails if any name isn't in `configspec.Vars`.

Critically, it's **AST-based, not regex-based** — `internal/config/config.go` reads env vars through helper functions (`envDefault`, `envBool`, `envDuration`) where the literal name sits at the call site, not inside an `os.Getenv` call. A regex over `os.Getenv\("..."\)` would miss those. The AST walker sees the string literal regardless of which function it's passed to.

```bash
go run ./hack/checkenvs
# checkenvs: 30 env-var name(s) referenced in source, all covered by spec.
```

### `Makefile`
Three new targets:

```make
docs:         go run ./hack/gendocs          # regenerate
docs-check:   checkenvs + gendocs --check    # CI guard
checkenvs:    go run ./hack/checkenvs        # standalone
```

### `.github/workflows/lint.yaml`
Two new steps in the `go-lint` job: `Verify configspec coverage` (runs `checkenvs`) and `Verify docs/configuration.md is up to date` (runs `gendocs --check`). Either failing breaks the PR.

### `internal/configspec/spec_test.go`
Unit test catches the four edits-by-hand mistakes:

- Empty `Name`
- Duplicate `Name`
- Unknown `Scope`
- Unknown `Kind`
- Empty `Description` (defensive — no var should be undocumented)

### `docs/configuration.md` (regenerated)
30 entries grouped by scope, with the previously-missing vars now documented. The file now opens with a banner explaining it's generated.

## How the drift guard catches things

| Change | Pre-PR | Post-PR |
| --- | --- | --- |
| Add `os.Getenv("PROVENANCE_NEW")` in code, forget the docs | Doc silently stale, no signal until someone notices | `checkenvs` fails: `PROVENANCE_NEW missing from configspec.Vars` |
| Add entry to `configspec.Vars`, forget to regenerate the doc | n/a | `gendocs --check` fails: `docs/configuration.md is stale` |
| Rename an env var in code, forget the spec/doc | Both stale, hard to notice | `checkenvs` fails on the new name, regenerate catches the old one |
| Add a hand-edit directly to `docs/configuration.md` | Edit appears to work; subsequent regen silently overwrites it | `gendocs --check` flags the unintended change in CI before it lands |

## Test plan

- [x] `go test ./...` green (includes new `configspec_test`).
- [x] `go vet ./...` clean.
- [x] `gofmt -l` clean.
- [x] `go run ./hack/checkenvs` returns 0 on current source.
- [x] `go run ./hack/gendocs --check` returns 0 after running `make docs`.
- [x] Manually inspected `docs/configuration.md` — 30 entries, three scopes, banner present.
- [ ] CI's new `lint` steps run on this PR and pass.
- [ ] Verify the drift guard by manually adding an `os.Getenv("PROVENANCE_FAKE")` to a test file and confirming `checkenvs` fails (out of scope for the merge, easy local check).

## Out of scope

- **Phase 2 typed-config refactor.** `cmd/dashboard/main.go` and `internal/config` still read env vars with inline `os.Getenv` + helper functions; only the *names* go through the spec. Binding the actual parsing through `configspec` (so adding a var to the spec also generates the parser code or a typed config struct) is worth doing but needs a design conversation — what's the runtime shape, do we keep envBool/envDuration as-is, etc. Open issue: revisit after this lands and stabilizes.

- **README's `## Configuration` table.** Currently still hand-maintained. Could be generated from the same spec; deliberately deferred to keep the diff focused.
