### PR TITLE
docs(spike): Hugo docs site at site/ via nebari-hugo-theme

### DIFF
--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -63,13 +63,11 @@ jobs:
         run: hugo mod get -u
 
       - name: Build site
-        run: |
-          hugo --minify \
-            --baseURL "${{ steps.pages.outputs.base_url || 'https://nebari-dev.github.io/nebari-provenance-collector-pack/' }}/"
-
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v6
+        # baseURL is hard-coded to the repo's Pages URL so PR builds don't
+        # need to query GitHub Pages configuration (which requires Pages to
+        # already be enabled on the repo). The deploy job below auto-enables
+        # Pages on the first push to main.
+        run: hugo --minify --baseURL "https://nebari-dev.github.io/nebari-provenance-collector-pack/"
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
@@ -85,6 +83,13 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+        with:
+          # Enables Pages on the repo the first time this job runs, so the
+          # very first deploy works without a manual settings tweak.
+          enablement: true
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -44,7 +44,11 @@ jobs:
       - name: Setup Go (Hugo Modules)
         uses: actions/setup-go@v6
         with:
-          go-version: "1.22"
+          # Hugo only uses Go for module resolution, not compilation. Track
+          # stable so the CI go version stays >= whatever `hugo mod init`
+          # writes into site/go.mod (Hugo derives that from the local
+          # environment's Go version).
+          go-version: "stable"
 
       - name: Install Hugo Extended
         run: |

--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -1,0 +1,86 @@
+name: Deploy docs site
+
+# Builds the Hugo docs site under site/ and publishes it to GitHub Pages.
+# Path-filtered so it only runs when the docs site itself changes; other
+# workflows (build-image, release, etc.) are unaffected.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - ".github/workflows/docs-deploy.yaml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "site/**"
+      - ".github/workflows/docs-deploy.yaml"
+  workflow_dispatch:
+
+# Permissions needed by actions/deploy-pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: docs-pages
+  cancel-in-progress: false
+
+env:
+  HUGO_VERSION: "0.140.0"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: site
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Needed for `enableGitInfo = true` to surface .Lastmod under page titles.
+          fetch-depth: 0
+
+      - name: Setup Go (Hugo Modules)
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.22"
+
+      - name: Install Hugo Extended
+        run: |
+          curl -sSL \
+            "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz" \
+            -o /tmp/hugo.tar.gz
+          tar -xzf /tmp/hugo.tar.gz -C /tmp hugo
+          sudo mv /tmp/hugo /usr/local/bin/hugo
+          hugo version
+
+      - name: Pull theme module
+        run: hugo mod get -u
+
+      - name: Build site
+        run: |
+          hugo --minify \
+            --baseURL "${{ steps.pages.outputs.base_url || 'https://nebari-dev.github.io/nebari-provenance-collector-pack/' }}/"
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/public
+
+  deploy:
+    # PRs build but don't publish — only push to main triggers a deploy.
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,12 +26,12 @@ jobs:
       # configspec drift guards. checkenvs fails if any os.Getenv (or a name
       # passed to one of the config helpers) references a PROVENANCE_* /
       # KUBECONFIG name that isn't in internal/configspec.Vars. gendocs --check
-      # fails if docs/configuration.md is stale relative to the spec. Together
-      # they keep the docs and the code from drifting.
+      # fails if site/content/reference/configuration.md is stale relative to
+      # the spec. Together they keep the docs and the code from drifting.
       - name: Verify configspec coverage
         run: go run ./hack/checkenvs
 
-      - name: Verify docs/configuration.md is up to date
+      - name: Verify site/content/reference/configuration.md is up to date
         run: go run ./hack/gendocs --check
 
   helm-lint:

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Setting `nebariapp.enabled: true` renders a `NebariApp` custom resource that reg
 landing-page registration so the web dashboard is reachable through the Nebari gateway under
 `https://<hostname>` and surfaced on the [Nebari Landing page](https://github.com/nebari-dev/nebari-landing).
 Leave it `false` for clusters that aren't running the operator. Full field reference:
-[docs/nebariapp-crd-reference.md](docs/nebariapp-crd-reference.md).
+[NebariApp CRD reference](site/content/reference/nebariapp-crd-reference.md).
 
 Verify:
 
@@ -136,7 +136,7 @@ kubectl get pods -n provenance-system -l app.kubernetes.io/name=provenance-colle
 | Cluster permissions | `cluster-admin` | Chart creates a `ClusterRole` + `ClusterRoleBinding` |
 
 > If you want `nebariapp.enabled: true` on a standalone cluster, the Nebari Operator CRDs must still be installed
-> first — see [docs/nebariapp-crd-reference.md](docs/nebariapp-crd-reference.md). Most standalone installs leave
+> first — see [NebariApp CRD reference](site/content/reference/nebariapp-crd-reference.md). Most standalone installs leave
 > `nebariapp.enabled: false` and access the dashboard via `kubectl port-forward`.
 
 #### Install
@@ -308,7 +308,7 @@ WHEN count() OF images WHERE updateAvailable = true IS ABOVE 0
 
 An example dashboard (11 panels covering unique images, signature status, SLSA provenance, Helm releases, and more) is available at [`examples/grafana-dashboard.json`](examples/grafana-dashboard.json). Import it directly into Grafana as a `dashboard.grafana.app/v2beta1` resource.
 
-See [docs/configuration.md](docs/configuration.md) for the full Grafana setup guide.
+See [configuration reference](site/content/reference/configuration.md) for the full Grafana setup guide.
 
 ## Configuration
 
@@ -334,7 +334,7 @@ All configuration is via environment variables, set through `values.yaml`:
 | `PROVENANCE_REGISTRY_TIMEOUT` | `30s` | Timeout for registry operations |
 | `PROVENANCE_CLUSTER_NAME` | *(empty)* | Cluster name in report metadata |
 
-See [docs/configuration.md](docs/configuration.md) for the full reference.
+See [configuration reference](site/content/reference/configuration.md) for the full reference.
 
 ## Report Format
 
@@ -388,7 +388,7 @@ Reports are JSON with this structure:
 }
 ```
 
-See [docs/report-schema.md](docs/report-schema.md) for the full schema reference.
+See [report schema reference](site/content/reference/report-schema.md) for the full schema reference.
 
 ## Helm Chart Values
 
@@ -574,9 +574,9 @@ make test
 
 - [Open issues](https://github.com/nebari-dev/nebari-provenance-collector-pack/issues) — bug reports, feature
   requests, and documentation gaps.
-- [Configuration reference](docs/configuration.md) — every env var and its chart value.
-- [Report schema](docs/report-schema.md) — JSON output structure.
-- [NebariApp CRD reference](docs/nebariapp-crd-reference.md) — operator integration fields.
+- [Configuration reference](site/content/reference/configuration.md) — every env var and its chart value.
+- [Report schema](site/content/reference/report-schema.md) — JSON output structure.
+- [NebariApp CRD reference](site/content/reference/nebariapp-crd-reference.md) — operator integration fields.
 - [Deployment examples](examples/) — standalone, Nebari, ArgoCD.
 
 ## License

--- a/hack/checkenvs/main.go
+++ b/hack/checkenvs/main.go
@@ -74,7 +74,7 @@ func main() {
 		}
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "Add each one to internal/configspec/spec.go with its Scope / Kind / Default / Description,")
-		fmt.Fprintln(os.Stderr, "then run `make docs` to regenerate docs/configuration.md.")
+		fmt.Fprintln(os.Stderr, "then run `make docs` to regenerate site/content/reference/configuration.md.")
 		os.Exit(1)
 	}
 

--- a/hack/gendocs/main.go
+++ b/hack/gendocs/main.go
@@ -1,8 +1,9 @@
-// gendocs renders docs/configuration.md from internal/configspec.Vars.
+// gendocs renders site/content/reference/configuration.md from
+// internal/configspec.Vars.
 //
 // Usage:
 //
-//	go run ./hack/gendocs           # write docs/configuration.md
+//	go run ./hack/gendocs           # write site/content/reference/configuration.md
 //	go run ./hack/gendocs --check   # exit 1 if the file on disk is stale
 //
 // `--check` exists so CI can fail a PR that touches the spec but doesn't
@@ -19,7 +20,7 @@ import (
 	"github.com/nebari-dev/provenance-collector/internal/configspec"
 )
 
-const outputPath = "docs/configuration.md"
+const outputPath = "site/content/reference/configuration.md"
 
 var docTemplate = template.Must(template.New("doc").Funcs(template.FuncMap{
 	"defaultCell": func(d string) string {
@@ -33,7 +34,10 @@ var docTemplate = template.Must(template.New("doc").Funcs(template.FuncMap{
 		}
 		return "`" + d + "`"
 	},
-}).Parse(`# Configuration Reference
+}).Parse(`+++
+title = "Configuration"
+description = "Every environment variable read by the collector and dashboard binaries, with type, default, and which scope sets it."
++++
 
 <!-- GENERATED FILE — do not edit by hand.
      Source of truth: internal/configspec/spec.go.

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,0 +1,4 @@
+public/
+resources/
+.hugo_build.lock
+screenshots/

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,53 @@
+# Provenance Collector docs site
+
+Hugo site for the pack's user-facing documentation. Consumes
+[`nebari-hugo-theme`](https://github.com/nebari-dev/nebari-hugo-theme) as a Hugo Module — this
+directory only contains content + a 70-line `hugo.toml`. The theme owns the chrome (header,
+sidebar, search, dark-mode toggle, code highlighting, callouts, breadcrumbs, ToC, edit-link).
+
+Built and deployed to GitHub Pages by [`.github/workflows/docs-deploy.yaml`](../.github/workflows/docs-deploy.yaml)
+on every push to `main` (and built without publishing on PRs that touch `site/`).
+
+## Local development
+
+```bash
+cd site
+hugo mod get -u   # first-time: pull the theme module
+hugo server       # http://localhost:1313/nebari-provenance-collector-pack/
+hugo              # build to public/
+```
+
+The `baseURL` in `hugo.toml` is set to the deployed Pages URL, so `hugo server` serves under
+that path prefix. Open `http://localhost:1313/nebari-provenance-collector-pack/` (not just `/`).
+
+## Layout
+
+```
+site/
+  hugo.toml           Theme config — tabs, sidebar tree, editBase, params
+  go.mod              Hugo Module init (theme is fetched on `hugo mod get`)
+  content/
+    _index.md         Overview landing
+    install.md        Install runbook (operator-managed + standalone)
+```
+
+## Adding a page
+
+Drop a `.md` under `content/`. Add a `[[params.sidebar.items]]` entry in `hugo.toml` to surface
+it in the left sidebar. The theme's ToC widget on the right is auto-generated from the H2/H3
+headings in the page.
+
+## What the theme provides
+
+See the [upstream README](https://github.com/nebari-dev/nebari-hugo-theme#whats-shipped) for
+the full feature list — search, code-block copy buttons, Mermaid diagrams, breadcrumbs,
+last-updated stamps, i18n, versioning, callout shortcodes, themed 404, responsive layout, etc.
+
+## Why a separate Hugo site?
+
+The reference markdowns under `../docs/` (`configuration.md`, `nebariapp-crd-reference.md`,
+`report-schema.md`) are CI-generated artifacts that the main `README.md` links to. The Hugo
+site under `site/` is the *human-readable* docs surface. If/when this skeleton graduates into
+[`nebari-software-pack-template`](https://github.com/nebari-dev/nebari-software-pack-template),
+every Nebari software pack inherits the same shape: `site/` for narrative docs, `docs/` for
+auto-generated references.

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -1,0 +1,41 @@
++++
+title = 'Provenance Collector'
+description = "A Kubernetes-native CronJob that discovers running images and Helm releases, resolves digests, verifies signatures, detects SLSA provenance and SBOM attestations, checks for updates, and emits a timestamped JSON report. Optionally surfaced via a web dashboard and Grafana."
++++
+
+The Provenance Collector is a **Nebari Software Pack** that produces compliance-grade
+supply-chain reports for every container image and Helm release running on a Kubernetes
+cluster. It is deployed automatically by the
+[Nebari Operator](https://github.com/nebari-dev/nebari-operator) as part of NIC's foundational
+software, runs on a schedule as a `CronJob`, and ships each timestamped JSON report to the
+built-in web dashboard, a shared PVC, or a ConfigMap.
+
+It exists because answering *"what is actually running on this cluster, where did it come from,
+and is it signed?"* should not require manual auditing.
+
+![Provenance Collector dashboard — image inventory with signature, SLSA, SBOM, and update status](https://raw.githubusercontent.com/nebari-dev/nebari-provenance-collector-pack/main/docs/screenshots/dashboard-overview.png)
+
+## What it does
+
+| Capability | Description |
+| --- | --- |
+| **Image Discovery** | Scans all pods across namespaces, deduplicates by workload owner |
+| **Digest Resolution** | Resolves every image tag to its immutable SHA256 digest |
+| **Signature Verification** | Checks for cosign signatures (existence or key-based verification) |
+| **SLSA Provenance** | Detects SLSA provenance attestations via OCI referrers API |
+| **SBOM Detection** | Detects attached SPDX / CycloneDX attestations |
+| **Update Checking** | Compares running tags against latest semver tags (configurable level, pre-release filtering) |
+| **Helm Release Tracking** | Discovers all deployed Helm releases with chart versions |
+| **Web Dashboard** | Optional UI with filters, sorting, pagination, and image detail panel |
+| **Grafana Integration** | JSON API compatible with the Infinity datasource for dashboards and alerting |
+| **Provenance Reports** | Timestamped JSON reports via the dashboard's upload endpoint (default), a shared PVC, or a ConfigMap, with automatic retention |
+
+{{< callout type="note" >}}
+Under active development as part of Nebari Infrastructure Core (NIC). APIs, chart values, and
+report schema may change without notice while pre-1.0.
+{{< /callout >}}
+
+## Get started
+
+Head to [**Install**](install/) for the operator-managed (recommended) and standalone install
+paths.

--- a/site/content/install.md
+++ b/site/content/install.md
@@ -1,0 +1,74 @@
++++
+title = 'Install'
+description = "Two paths to install the Provenance Collector pack: operator-managed default, and standalone for vanilla Kubernetes."
++++
+
+The Provenance Collector is normally installed by the Nebari Operator as part of NIC's
+foundational software — you don't run `helm` yourself, the operator and ArgoCD do it for you.
+
+## Operator-managed install (default)
+
+A complete ArgoCD `Application` manifest lives at
+[`examples/argocd-application.yaml`](https://github.com/nebari-dev/nebari-provenance-collector-pack/blob/main/examples/argocd-application.yaml)
+and is auto-stamped to the latest released chart version on every release. Apply it from your
+gitops repo or directly:
+
+```bash
+kubectl apply -f examples/argocd-application.yaml
+```
+
+The values most users adjust:
+
+```yaml
+nebariapp:
+  enabled: true                       # register the pack with the Nebari Operator
+  hostname: provenance.<your-domain>  # public URL the dashboard responds on
+
+webUI:
+  enabled: true                       # default true; required when persistence.mode=http
+  features:
+    timelineDeltas: false             # opt-in; show +N/-N badges between scans
+```
+
+### Verify
+
+```bash
+kubectl get application provenance-collector -n argocd
+kubectl get cronjob -n provenance-system
+kubectl get pods -n provenance-system -l app.kubernetes.io/name=provenance-collector
+```
+
+The operator wires routing (Envoy Gateway), OIDC (Keycloak), and surfaces the dashboard on the
+Nebari Landing page — no extra config needed beyond `hostname`.
+
+## Standalone install (without the Nebari Operator)
+
+{{< callout type="warning" >}}
+Use this path only on a vanilla Kubernetes cluster *without* NIC. Without the operator you're
+responsible for routing and OIDC yourself if you want the dashboard reachable from outside the
+cluster.
+{{< /callout >}}
+
+### Prerequisites
+
+| Tool | Minimum version | Notes |
+| --- | --- | --- |
+| `kubectl` | 1.26+ | Cluster interaction |
+| `helm` | 3.14+ | Chart install |
+| Kubernetes cluster | 1.26+ | Local (kind / k3d / minikube) or remote |
+| Cluster permissions | `cluster-admin` | Chart creates a `ClusterRole` + `ClusterRoleBinding` |
+
+### Install
+
+```bash
+helm repo add nebari https://nebari-dev.github.io/helm-repository
+helm repo update
+
+helm install provenance-collector nebari/provenance-collector \
+  --namespace provenance-system \
+  --create-namespace
+```
+
+See the
+[repo README](https://github.com/nebari-dev/nebari-provenance-collector-pack#standalone-install-without-the-nebari-operator)
+for the full standalone runbook (verify, trigger a manual run, view the report, uninstall).

--- a/site/content/reference/configuration.md
+++ b/site/content/reference/configuration.md
@@ -1,4 +1,7 @@
-# Configuration Reference
++++
+title = "Configuration"
+description = "Every environment variable read by the collector and dashboard binaries, with type, default, and which scope sets it."
++++
 
 <!-- GENERATED FILE — do not edit by hand.
      Source of truth: internal/configspec/spec.go.

--- a/site/content/reference/nebariapp-crd-reference.md
+++ b/site/content/reference/nebariapp-crd-reference.md
@@ -1,4 +1,8 @@
-# NebariApp CRD Reference
++++
+title = "NebariApp CRD"
+description = "Complete field-by-field reference for the NebariApp custom resource (reconcilers.nebari.dev/v1)."
++++
+
 
 Complete field-by-field reference for the NebariApp custom resource.
 

--- a/site/content/reference/report-schema.md
+++ b/site/content/reference/report-schema.md
@@ -1,4 +1,8 @@
-# Report Schema Reference
++++
+title = "Report schema"
+description = "JSON output structure emitted by the provenance collector."
++++
+
 
 The provenance collector outputs JSON reports with the following structure.
 

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,0 +1,5 @@
+module github.com/nebari-dev/nebari-provenance-collector-pack/site
+
+go 1.25.0
+
+require github.com/nebari-dev/nebari-hugo-theme v0.0.0-20260618170737-6d0f02a4d3e2 // indirect

--- a/site/go.sum
+++ b/site/go.sum
@@ -1,0 +1,2 @@
+github.com/nebari-dev/nebari-hugo-theme v0.0.0-20260618170737-6d0f02a4d3e2 h1:zKCaD1yhvyZwGYNtdV7Q3EDmcK8e59VIBBRpqt2IHjM=
+github.com/nebari-dev/nebari-hugo-theme v0.0.0-20260618170737-6d0f02a4d3e2/go.mod h1:N0PJCjHPJ69fOjfhNfaZsXcr+0CryBTJ7xEx7pmARSk=

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -1,0 +1,72 @@
+baseURL      = "https://nebari-dev.github.io/nebari-provenance-collector-pack/"
+languageCode = "en-US"
+title        = "Provenance Collector"
+theme        = ["github.com/nebari-dev/nebari-hugo-theme"]
+
+# Pull last-commit date for each markdown so the "Last updated" stamp
+# under page titles works.
+enableGitInfo = true
+
+[markup]
+  [markup.highlight]
+    noClasses   = false
+    codeFences  = true
+    guessSyntax = true
+  [markup.goldmark.renderer]
+    unsafe = true
+
+# Required for client-side Fuse.js search — emits /index.json that the
+# theme's search.ts fetches.
+[outputs]
+  home = ["HTML", "RSS", "JSON"]
+
+[params]
+  description = "Compliance-grade provenance for every container running on your Nebari cluster."
+  repo        = "https://github.com/nebari-dev/nebari-provenance-collector-pack"
+  search      = true
+  # "Edit this page on GitHub" link at the bottom of every page.
+  editBase    = "https://github.com/nebari-dev/nebari-provenance-collector-pack/edit/main/site/content"
+
+# Top-nav tabs. Active tab is determined by RelPermalink-prefix match.
+[[params.tabs]]
+  name = "Docs"
+  url  = "/"
+
+# Sidebar tree. Items are either {label, url} (real page) or
+# {label, soon=true} (stub with "soon" badge).
+[[params.sidebar]]
+  heading = "Getting Started"
+  [[params.sidebar.items]]
+    label = "Overview"
+    url   = "/"
+  [[params.sidebar.items]]
+    label = "Install"
+    url   = "/install/"
+
+[[params.sidebar]]
+  heading = "Reference"
+  [[params.sidebar.items]]
+    label = "Configuration"
+    soon  = true
+  [[params.sidebar.items]]
+    label = "NebariApp CRD"
+    soon  = true
+  [[params.sidebar.items]]
+    label = "Report schema"
+    soon  = true
+
+[[params.sidebar]]
+  heading = "Operating"
+  [[params.sidebar.items]]
+    label = "Dashboard tour"
+    soon  = true
+  [[params.sidebar.items]]
+    label = "Grafana integration"
+    soon  = true
+
+[module]
+  [module.hugoVersion]
+    extended = false
+    min      = "0.116.0"
+  [[module.imports]]
+    path = "github.com/nebari-dev/nebari-hugo-theme"

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -47,13 +47,13 @@ enableGitInfo = true
   heading = "Reference"
   [[params.sidebar.items]]
     label = "Configuration"
-    soon  = true
+    url   = "/reference/configuration/"
   [[params.sidebar.items]]
     label = "NebariApp CRD"
-    soon  = true
+    url   = "/reference/nebariapp-crd-reference/"
   [[params.sidebar.items]]
     label = "Report schema"
-    soon  = true
+    url   = "/reference/report-schema/"
 
 [[params.sidebar]]
   heading = "Operating"


### PR DESCRIPTION
## Summary

Reframes the docs-site spike from **Astro + shadcn registry** (PR #41) to **Hugo + [`nebari-dev/nebari-hugo-theme`](https://github.com/nebari-dev/nebari-hugo-theme)**  -  a Nebari-themed Hugo theme that owns layout, chrome, search, dark mode, code highlighting, callouts, breadcrumbs, ToC, and the responsive layout. This repo only ships docs *content*.

> **Why the pivot:** see the conclusion comment on `nebari-software-pack-template#14` (pending) and the discussion under PR #41. Short version: for pack docs specifically, the design-system value is *tokens, not components*  -  Hugo imports the OKLCH tokens just as well as Astro, and the per-pack overhead drops to a 70-line `hugo.toml` + markdown content.

## What's in this PR

15 files changed, +380 / -19.

```
site/                                       (new)
  hugo.toml                                 70 lines: theme module import, tabs, sidebar tree, editBase
  go.mod / go.sum                           Hugo Module init (theme fetched from upstream)
  .gitignore                                public/, resources/, .hugo_build.lock, screenshots/
  README.md                                 Contributor docs
  content/
    _index.md                               Overview landing
    install.md                              Operator-managed + standalone runbook
    reference/                              (migrated  -  see below)
      configuration.md                      <- docs/configuration.md     (CI-generated)
      nebariapp-crd-reference.md            <- docs/nebariapp-crd-reference.md
      report-schema.md                      <- docs/report-schema.md

.github/workflows/
  docs-deploy.yaml                          (new) Hugo extended + GitHub Pages
  lint.yaml                                 (M) gendocs --check + comment point at new path

hack/
  gendocs/main.go                           (M) outputPath -> site/content/reference/configuration.md;
                                                 generated content gets TOML frontmatter (title + description)
                                                 replacing the bare H1  -  theme renders the title once.
                                                 CI staleness guard intact.
  checkenvs/main.go                         (M) error message references new path

README.md                                   (M) cross-refs updated to site/content/reference/<file>
                                                with cleaner link text
```

No `docs-site/`, no `node_modules/`, no React, no MDX, no per-pack TypeScript. The Astro spike from PR #41 never landed on `main`, so this PR is purely additive vs. the current `main`.

## Docs migration (preserves all existing automation)

The existing `docs/*.md` files were either CI-generated or hand-written references that the main README links to. All three move into the Hugo site so they're sidebar-navigable and searchable:

| File | Before | After | Automation |
| --- | --- | --- | --- |
| `configuration.md` | `docs/configuration.md` | `site/content/reference/configuration.md` | **Still auto-generated** by `hack/gendocs` from `internal/configspec/spec.go`. CI runs `gendocs --check` on every PR (unchanged behavior, new path). The Hugo theme renders the title from frontmatter; the `GENERATED FILE` comment + "Generated from spec" callout are preserved. |
| `nebariapp-crd-reference.md` | `docs/nebariapp-crd-reference.md` | `site/content/reference/nebariapp-crd-reference.md` | Hand-written, moved with TOML frontmatter; leading `# H1` stripped (theme renders title from frontmatter). |
| `report-schema.md` | `docs/report-schema.md` | `site/content/reference/report-schema.md` | Same as above. |

`docs/screenshots/` stays where it is  -  `test-integration.yaml` writes `docs/screenshots/dashboard-*.png` via puppeteer and auto-commits the result. The main README and `site/content/_index.md` both embed via the raw GitHub URL, so the path stays load-bearing. Moving screenshots would mean touching the test workflow too, which is out of scope for this PR.

`site/hugo.toml` promotes the three Reference sidebar items from `soon=true` stubs to real linked pages now that their content is in.

## Comparison vs the Astro spike (PR #41)

| | **Astro (PR #41)** | **Hugo (this PR)** |
| --- | --- | --- |
| Pack ships | layout, components, build wiring, MDX pages | content + 70-line `hugo.toml` |
| Theme/chrome lives in | the pack repo | upstream `nebari-hugo-theme` Hugo Module |
| Diff size | ~30 files of layout/components/build wiring | 15 files (7 new site/ + 3 renames + 5 minor edits to existing files) |
| Build | `astro build && pagefind --site dist` | `hugo --minify` |
| Toolchain | Node 20 + npm + Astro + Tailwind v4 + React 19 + MDX | Hugo extended + Go (modules only) |
| Visual identity | OKLCH tokens via Tailwind v4 `@theme inline` | OKLCH tokens via theme `assets/css/main.css` |

## What the theme provides

(All of these are in the upstream theme  -  this repo doesn't configure or implement any of them.)

- Header chrome with multi-tab nav (`[[params.tabs]]`), client-side Fuse.js search with `/`-focus shortcut, dark-mode toggle with FOUC prevention
- Left sidebar with section grouping (`[[params.sidebar]]`), collapsible groups, active-state highlight, "soon" badges for stub pages
- Right-side "On this page" ToC with scroll-spy
- Breadcrumbs, last-updated stamp (from git), "Edit this page on GitHub" link (`params.editBase`)
- Copy buttons on code blocks, Mermaid diagrams, heading-anchor permalinks
- Catppuccin Mocha syntax highlighting, Poppins + Atkinson Hyperlegible + Fira Code self-hosted fonts
- Callout shortcodes: `{{< callout type="note" >}}` / `tip` / `warning` / `caution`
- Responsive layout (off-canvas sidebar + hamburger under 768px)
- Themed 404 page
- i18n + versioning hooks (not used by this consumer)

## Deploy

`.github/workflows/docs-deploy.yaml` is path-filtered to `site/**` and `.github/workflows/docs-deploy.yaml`. PRs build (no publish); pushes to `main` build + deploy via `actions/upload-pages-artifact` + `actions/deploy-pages`. The deploy job calls `actions/configure-pages` with `enablement: true`, so the first push to main also auto-enables Pages on the repo  -  no manual settings tweak required.

Site will live at <https://nebari-dev.github.io/nebari-provenance-collector-pack/> once merged.

## Test plan

- [x] CI: `docs-deploy: build` passes (verified)
- [x] CI: `go-lint` / `helm-lint` / `unit-test` pass (verified  -  migration of `gendocs` output path is transparent to the existing CI guard)
- [x] CI: `docs-deploy: deploy` correctly skipped on PR (only fires on push-to-main)
- [x] Local: `cd site && hugo` builds 15 pages with no errors; reference pages render with frontmatter title and theme chrome
- [x] Local: `go run ./hack/gendocs --check` passes against the new output path
- [ ] Post-merge: GitHub Pages publishes successfully to the deploy URL and the reference pages are searchable + sidebar-navigable

## Follow-ups (not in this PR)

- Replace the dashboard screenshot URL in `site/content/_index.md` with a path inside the Hugo site once `docs/screenshots/` is moved (requires updating `test-integration.yaml`).
- If the spike lands, lift this skeleton into `nebari-software-pack-template` so future packs inherit the same shape.
