### PR TITLE
fix(verify): detect SBOMs via OCI referrers index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   release (Helm chart to nebari-dev/helm-repository)
 - SecurityContext hardening (runAsNonRoot, readOnlyRootFilesystem, drop ALL
   capabilities)
+
+### Fixed
+- SBOM detection now reads the OCI referrers index, the same source provenance
+  detection uses, so SBOMs attached by `docker/build-push-action` (`sbom: true`)
+  are discovered and shown in the dashboard. The legacy cosign attestation tag
+  (`.att`) is retained as a fallback for images attested with older `cosign
+  attest` runs.

--- a/internal/verify/provenance.go
+++ b/internal/verify/provenance.go
@@ -2,11 +2,7 @@ package verify
 
 import (
 	"context"
-	"fmt"
 	"strings"
-
-	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	"github.com/nebari-dev/provenance-collector/internal/report"
 )
@@ -32,52 +28,17 @@ var slsaPredicates = []string{
 }
 
 func (c *SLSAProvenanceChecker) Check(ctx context.Context, imageRef string) (*report.ProvenanceInfo, error) {
-	ref, err := name.ParseReference(imageRef)
+	manifests, err := referrerManifests(ctx, imageRef)
 	if err != nil {
 		return &report.ProvenanceInfo{}, nil
 	}
 
-	desc, err := remote.Get(ref, remote.WithContext(ctx))
-	if err != nil {
-		return &report.ProvenanceInfo{}, nil
-	}
-
-	// Check the OCI referrers tag fallback: <algo>-<hex>
-	referrersTag := strings.Replace(desc.Digest.String(), ":", "-", 1)
-	referrersRef, err := name.ParseReference(fmt.Sprintf("%s:%s", ref.Context().String(), referrersTag))
-	if err != nil {
-		return &report.ProvenanceInfo{}, nil
-	}
-
-	idx, err := remote.Index(referrersRef, remote.WithContext(ctx))
-	if err != nil {
-		return &report.ProvenanceInfo{}, nil
-	}
-
-	manifest, err := idx.IndexManifest()
-	if err != nil || manifest == nil {
-		return &report.ProvenanceInfo{}, nil
-	}
-
-	for _, m := range manifest.Manifests {
-		at := string(m.ArtifactType)
-		// Check artifactType for sigstore bundles
-		if at != "" {
-			predType := m.Annotations["dev.sigstore.bundle.predicateType"]
-			if isSLSAPredicate(predType) {
+	for _, m := range manifests {
+		for _, pt := range predicateTypes(m) {
+			if isSLSAPredicate(pt) {
 				return &report.ProvenanceInfo{
 					HasProvenance: true,
-					PredicateType: predType,
-				}, nil
-			}
-		}
-
-		// Check annotations directly for predicate types
-		for _, v := range m.Annotations {
-			if isSLSAPredicate(v) {
-				return &report.ProvenanceInfo{
-					HasProvenance: true,
-					PredicateType: v,
+					PredicateType: pt,
 				}, nil
 			}
 		}

--- a/internal/verify/referrers.go
+++ b/internal/verify/referrers.go
@@ -1,0 +1,80 @@
+package verify
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+// Annotation keys that carry the in-toto predicate type of a referring
+// attestation manifest. Sigstore bundles use the first; buildx / BuildKit
+// attestation manifests use the second.
+const (
+	annoSigstorePredicateType = "dev.sigstore.bundle.predicateType"
+	annoInTotoPredicateType   = "in-toto.io/predicate-type"
+)
+
+// referrerManifests resolves imageRef, then reads the OCI referrers index via
+// the <algo>-<hex> fallback tag derived from the image digest, and returns the
+// referring manifest descriptors. Attestations attached by cosign (bundle
+// format) and by docker/build-push-action (sbom/provenance) both land here.
+//
+// Every failure (bad ref, unreachable registry, no referrers tag) returns an
+// empty slice and a nil error: a missing referrers index is the common case,
+// not an error worth surfacing to the caller.
+func referrerManifests(ctx context.Context, imageRef string) ([]v1.Descriptor, error) {
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return nil, nil
+	}
+
+	desc, err := remote.Get(ref, remote.WithContext(ctx))
+	if err != nil {
+		return nil, nil
+	}
+
+	referrersTag := strings.Replace(desc.Digest.String(), ":", "-", 1)
+	referrersRef, err := name.ParseReference(fmt.Sprintf("%s:%s", ref.Context().String(), referrersTag))
+	if err != nil {
+		return nil, nil
+	}
+
+	idx, err := remote.Index(referrersRef, remote.WithContext(ctx))
+	if err != nil {
+		return nil, nil
+	}
+
+	manifest, err := idx.IndexManifest()
+	if err != nil || manifest == nil {
+		return nil, nil
+	}
+
+	return manifest.Manifests, nil
+}
+
+// predicateTypes returns the candidate in-toto predicate types advertised by a
+// referring manifest descriptor: the dedicated sigstore/in-toto annotations
+// first, then every other annotation value as a fallback (some producers stash
+// the predicate type under non-standard keys).
+func predicateTypes(d v1.Descriptor) []string {
+	var out []string
+	if pt := d.Annotations[annoSigstorePredicateType]; pt != "" {
+		out = append(out, pt)
+	}
+	if pt := d.Annotations[annoInTotoPredicateType]; pt != "" {
+		out = append(out, pt)
+	}
+	for k, v := range d.Annotations {
+		if k == annoSigstorePredicateType || k == annoInTotoPredicateType {
+			continue
+		}
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}

--- a/internal/verify/referrers_test.go
+++ b/internal/verify/referrers_test.go
@@ -1,0 +1,68 @@
+package verify
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+func TestPredicateTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		desc v1.Descriptor
+		want []string // membership check, order-independent
+	}{
+		{
+			name: "sigstore bundle annotation",
+			desc: v1.Descriptor{Annotations: map[string]string{
+				annoSigstorePredicateType: "https://slsa.dev/provenance/v1",
+			}},
+			want: []string{"https://slsa.dev/provenance/v1"},
+		},
+		{
+			name: "buildx in-toto annotation",
+			desc: v1.Descriptor{Annotations: map[string]string{
+				annoInTotoPredicateType: "https://spdx.dev/Document",
+			}},
+			want: []string{"https://spdx.dev/Document"},
+		},
+		{
+			name: "non-standard annotation falls through",
+			desc: v1.Descriptor{Annotations: map[string]string{
+				"org.example.predicate": "https://cyclonedx.org/bom",
+			}},
+			want: []string{"https://cyclonedx.org/bom"},
+		},
+		{
+			name: "no annotations",
+			desc: v1.Descriptor{},
+			want: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := predicateTypes(tc.desc)
+			for _, w := range tc.want {
+				if !slices.Contains(got, w) {
+					t.Errorf("predicateTypes() = %v, want to contain %q", got, w)
+				}
+			}
+			if len(tc.want) == 0 && len(got) != 0 {
+				t.Errorf("predicateTypes() = %v, want empty", got)
+			}
+		})
+	}
+}
+
+func TestReferrerManifests_InvalidRef(t *testing.T) {
+	got, err := referrerManifests(context.Background(), ":::invalid")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no manifests for invalid ref, got %d", len(got))
+	}
+}

--- a/internal/verify/sbom.go
+++ b/internal/verify/sbom.go
@@ -25,24 +25,63 @@ func NewSBOMDiscoverer() SBOMDiscoverer {
 }
 
 func (d *OCISBOMDiscoverer) Discover(ctx context.Context, imageRef string) (*report.SBOMInfo, error) {
+	// Primary path: the OCI referrers index. SBOM attestations attached by
+	// docker/build-push-action (sbom: true) and by cosign's bundle format
+	// land here as referring manifests, advertising their format through the
+	// in-toto predicate type. This mirrors how provenance.go finds SLSA
+	// attestations, so the two stay in lock-step.
+	if info := discoverFromReferrers(ctx, imageRef); info != nil {
+		return info, nil
+	}
+
+	// Fallback: the legacy cosign attestation tag (sha256-<hex>.att) produced
+	// by older `cosign attest` runs that predate the referrers/bundle format.
+	if info := discoverFromCosignAtt(imageRef); info != nil {
+		return info, nil
+	}
+
+	return &report.SBOMInfo{HasSBOM: false}, nil
+}
+
+// discoverFromReferrers looks for an SBOM attestation in the image's OCI
+// referrers index. Returns nil when no SBOM-typed referrer is found, so the
+// caller can fall through to the legacy path.
+func discoverFromReferrers(ctx context.Context, imageRef string) *report.SBOMInfo {
+	manifests, err := referrerManifests(ctx, imageRef)
+	if err != nil {
+		return nil
+	}
+	for _, m := range manifests {
+		for _, pt := range predicateTypes(m) {
+			if format := sbomFormatFromPredicate(pt); format != "" {
+				return &report.SBOMInfo{HasSBOM: true, Format: format}
+			}
+		}
+	}
+	return nil
+}
+
+// discoverFromCosignAtt looks for an SBOM in the legacy cosign attestation tag.
+// Returns nil when nothing usable is found.
+func discoverFromCosignAtt(imageRef string) *report.SBOMInfo {
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {
-		return &report.SBOMInfo{}, nil
+		return nil
 	}
 
 	se, err := ociremote.SignedEntity(ref)
 	if err != nil {
-		return &report.SBOMInfo{}, nil
+		return nil
 	}
 
 	atts, err := se.Attestations()
 	if err != nil {
-		return &report.SBOMInfo{}, nil
+		return nil
 	}
 
 	attList, err := atts.Get()
 	if err != nil || len(attList) == 0 {
-		return &report.SBOMInfo{HasSBOM: false}, nil
+		return nil
 	}
 
 	for _, att := range attList {
@@ -50,16 +89,12 @@ func (d *OCISBOMDiscoverer) Discover(ctx context.Context, imageRef string) (*rep
 		if err != nil {
 			continue
 		}
-		format := detectSBOMFormat(payload)
-		if format != "" {
-			return &report.SBOMInfo{
-				HasSBOM: true,
-				Format:  format,
-			}, nil
+		if format := detectSBOMFormat(payload); format != "" {
+			return &report.SBOMInfo{HasSBOM: true, Format: format}
 		}
 	}
 
-	return &report.SBOMInfo{HasSBOM: false}, nil
+	return nil
 }
 
 // Known in-toto predicate types for SBOM formats.
@@ -67,6 +102,19 @@ const (
 	predicateSPDX      = "https://spdx.dev/Document"
 	predicateCycloneDX = "https://cyclonedx.org/bom"
 )
+
+// sbomFormatFromPredicate maps an in-toto predicate type to an SBOM format,
+// returning "" when the predicate type is not an SBOM.
+func sbomFormatFromPredicate(predicateType string) string {
+	switch {
+	case strings.HasPrefix(predicateType, predicateSPDX):
+		return "spdx"
+	case strings.HasPrefix(predicateType, predicateCycloneDX):
+		return "cyclonedx"
+	default:
+		return ""
+	}
+}
 
 // inTotoStatement represents the minimal structure of an in-toto attestation
 // needed to extract the predicate type.

--- a/internal/verify/sbom_test.go
+++ b/internal/verify/sbom_test.go
@@ -1,6 +1,7 @@
 package verify
 
 import (
+	"context"
 	"testing"
 )
 
@@ -85,6 +86,52 @@ func TestNewSBOMDiscoverer(t *testing.T) {
 	}
 	if _, ok := d.(*OCISBOMDiscoverer); !ok {
 		t.Error("expected *OCISBOMDiscoverer")
+	}
+}
+
+func TestSBOMFormatFromPredicate(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://spdx.dev/Document", "spdx"},
+		{"https://spdx.dev/Document/v2.3", "spdx"},
+		{"https://cyclonedx.org/bom", "cyclonedx"},
+		{"https://cyclonedx.org/bom/v1.5", "cyclonedx"},
+		{"https://slsa.dev/provenance/v1", ""},
+		{"https://in-toto.io/provenance/v1", ""},
+		{"", ""},
+		{"random", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			if got := sbomFormatFromPredicate(tc.input); got != tc.want {
+				t.Errorf("sbomFormatFromPredicate(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOCISBOMDiscoverer_InvalidRef(t *testing.T) {
+	d := NewSBOMDiscoverer()
+	info, err := d.Discover(context.Background(), ":::invalid")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.HasSBOM {
+		t.Error("expected no SBOM for invalid ref")
+	}
+}
+
+func TestOCISBOMDiscoverer_UnreachableImage(t *testing.T) {
+	d := NewSBOMDiscoverer()
+	// Registry calls fail; should return HasSBOM=false without an error.
+	info, err := d.Discover(context.Background(), "localhost:1/nonexistent:v0.0.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.HasSBOM {
+		t.Error("expected no SBOM for unreachable image")
 	}
 }
 


### PR DESCRIPTION
## What

Fixes #46 - the dashboard showed `imagesWithSBOM = 0` and per-image SBOM status as "None" even for images that genuinely had SBOM attestations attached.

## Why

SBOM and SLSA provenance were detected through two different, incompatible mechanisms:

- **Provenance** (`internal/verify/provenance.go`) walked the **OCI referrers index** (resolve digest, read the `<algo>-<hex>` referrers tag, match predicate types in the manifest annotations).
- **SBOM** (`internal/verify/sbom.go`) used the **legacy cosign attestation tag** via `SignedEntity().Attestations()`, which triangulates to the `sha256-<hex>.att` tag.

SBOMs attached by `docker/build-push-action` (`sbom: true`, which is how our own image ships them per #29/#31) land in the referrers index, **not** the `.att` tag. So `sbom.go` found nothing and returned `hasSBOM: false`, while provenance - attached the same way, in the same index - rendered fine. That asymmetry is the bug.

## Change

- New `internal/verify/referrers.go` factors out the referrers-index walk (`referrerManifests`) and predicate-type extraction (`predicateTypes`), so SBOM and provenance now read the **same source** and can't drift apart again.
- `sbom.go` discovers SBOMs from the referrers index first (matching the SPDX `https://spdx.dev/Document` and CycloneDX `https://cyclonedx.org/bom` in-toto predicate types), then falls back to the legacy `.att` lookup so images attested with older `cosign attest` runs still resolve.
- `provenance.go` refactored onto the shared helper. Behavior is preserved (slightly broader: the predicate-type annotation is now always considered, not only when `artifactType` is set).

## Test plan

- `go test ./...` passes.
- Added unit tests: `sbomFormatFromPredicate` mapping, `predicateTypes` extraction from descriptors, and invalid/unreachable-ref handling for the SBOM discoverer (mirrors the existing provenance tests).
- Existing `detectSBOMFormat` / `.att`-payload tests retained - that path is now the fallback.

Not covered by unit tests: a live registry round-trip against a buildx-attested image. Worth confirming on a real cluster (or wiring a positive assertion into the e2e suite, which #29 notes is currently impossible) that the collector's own image now reports `hasSBOM: true`.
