### PR TITLE
fix(verify): detect SBOMs/provenance via OCI referrers and BuildKit in-index attestations (closes #46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   release (Helm chart to nebari-dev/helm-repository)
 - SecurityContext hardening (runAsNonRoot, readOnlyRootFilesystem, drop ALL
   capabilities)
+
+### Fixed
+- SBOM detection now reads the OCI referrers index, the same source provenance
+  detection uses, so SBOMs attached by `docker/build-push-action` (`sbom: true`)
+  are discovered and shown in the dashboard. The legacy cosign attestation tag
+  (`.att`) is retained as a fallback for images attested with older `cosign
+  attest` runs.

--- a/internal/verify/buildkit_attest_test.go
+++ b/internal/verify/buildkit_attest_test.go
@@ -1,0 +1,138 @@
+package verify
+
+import (
+	"context"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+const inTotoLayerMediaType = types.MediaType("application/vnd.in-toto+json")
+
+// pushBuildKitIndex publishes a multi-arch index that mirrors the layout
+// docker buildx / docker/build-push-action produces: a normal image manifest
+// plus an unknown/unknown attestation manifest (vnd.docker.reference.type=
+// attestation-manifest) whose layers carry the given in-toto predicate types.
+// It returns the image reference string.
+func pushBuildKitIndex(t *testing.T, predicateTypes ...string) string {
+	t.Helper()
+
+	srv := httptest.NewServer(registry.New())
+	t.Cleanup(srv.Close)
+	host := strings.TrimPrefix(srv.URL, "http://")
+	refStr := host + "/test/buildkit:latest"
+
+	ref, err := name.ParseReference(refStr)
+	if err != nil {
+		t.Fatalf("parse ref: %v", err)
+	}
+
+	// A normal platform image.
+	img, err := random.Image(256, 1)
+	if err != nil {
+		t.Fatalf("random image: %v", err)
+	}
+
+	// The attestation manifest: an image whose layers advertise predicate types.
+	att := mutate.MediaType(empty.Image, types.OCIManifestSchema1)
+	for _, pt := range predicateTypes {
+		layer := static.NewLayer([]byte(`{"predicate":"test"}`), inTotoLayerMediaType)
+		att, err = mutate.Append(att, mutate.Addendum{
+			Layer:       layer,
+			Annotations: map[string]string{annoInTotoPredicateType: pt},
+		})
+		if err != nil {
+			t.Fatalf("append attestation layer: %v", err)
+		}
+	}
+
+	idx := mutate.AppendManifests(empty.Index,
+		mutate.IndexAddendum{
+			Add: img,
+			Descriptor: v1.Descriptor{
+				Platform: &v1.Platform{OS: "linux", Architecture: "amd64"},
+			},
+		},
+		mutate.IndexAddendum{
+			Add: att,
+			Descriptor: v1.Descriptor{
+				Platform:    &v1.Platform{OS: "unknown", Architecture: "unknown"},
+				Annotations: map[string]string{annoDockerReferenceType: attestationManifestType},
+			},
+		},
+	)
+
+	if err := remote.WriteIndex(ref, idx); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+	return refStr
+}
+
+func TestIndexAttestationPredicateTypes_BuildKit(t *testing.T) {
+	ref := pushBuildKitIndex(t, predicateSPDX, "https://slsa.dev/provenance/v0.2")
+
+	got := indexAttestationPredicateTypes(context.Background(), ref)
+	for _, want := range []string{predicateSPDX, "https://slsa.dev/provenance/v0.2"} {
+		if !slices.Contains(got, want) {
+			t.Errorf("indexAttestationPredicateTypes() = %v, want to contain %q", got, want)
+		}
+	}
+}
+
+func TestOCISBOMDiscoverer_BuildKitIndexAttestation(t *testing.T) {
+	// SBOM stored only as a BuildKit in-index attestation manifest — the case
+	// the referrers fallback tag cannot see. This is the regression target.
+	ref := pushBuildKitIndex(t, predicateSPDX)
+
+	info, err := NewSBOMDiscoverer().Discover(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if info == nil || !info.HasSBOM {
+		t.Fatalf("expected HasSBOM=true for BuildKit SPDX attestation, got %+v", info)
+	}
+	if info.Format != "spdx" {
+		t.Errorf("expected format spdx, got %q", info.Format)
+	}
+}
+
+func TestSLSAProvenanceChecker_BuildKitIndexAttestation(t *testing.T) {
+	ref := pushBuildKitIndex(t, "https://slsa.dev/provenance/v0.2")
+
+	info, err := NewProvenanceChecker().Check(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if info == nil || !info.HasProvenance {
+		t.Fatalf("expected HasProvenance=true for BuildKit SLSA attestation, got %+v", info)
+	}
+	if info.PredicateType != "https://slsa.dev/provenance/v0.2" {
+		t.Errorf("unexpected predicate type %q", info.PredicateType)
+	}
+}
+
+func TestOCISBOMDiscoverer_BuildKitIndexNoSBOM(t *testing.T) {
+	// Provenance-only attestation (the dex / build-push-action default): no
+	// SBOM layer, so detection must report HasSBOM=false rather than a false
+	// positive.
+	ref := pushBuildKitIndex(t, "https://slsa.dev/provenance/v1")
+
+	info, err := NewSBOMDiscoverer().Discover(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if info == nil || info.HasSBOM {
+		t.Fatalf("expected HasSBOM=false for provenance-only image, got %+v", info)
+	}
+}

--- a/internal/verify/provenance.go
+++ b/internal/verify/provenance.go
@@ -2,11 +2,7 @@ package verify
 
 import (
 	"context"
-	"fmt"
 	"strings"
-
-	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	"github.com/nebari-dev/provenance-collector/internal/report"
 )
@@ -32,52 +28,17 @@ var slsaPredicates = []string{
 }
 
 func (c *SLSAProvenanceChecker) Check(ctx context.Context, imageRef string) (*report.ProvenanceInfo, error) {
-	ref, err := name.ParseReference(imageRef)
+	manifests, err := referrerManifests(ctx, imageRef)
 	if err != nil {
 		return &report.ProvenanceInfo{}, nil
 	}
 
-	desc, err := remote.Get(ref, remote.WithContext(ctx))
-	if err != nil {
-		return &report.ProvenanceInfo{}, nil
-	}
-
-	// Check the OCI referrers tag fallback: <algo>-<hex>
-	referrersTag := strings.Replace(desc.Digest.String(), ":", "-", 1)
-	referrersRef, err := name.ParseReference(fmt.Sprintf("%s:%s", ref.Context().String(), referrersTag))
-	if err != nil {
-		return &report.ProvenanceInfo{}, nil
-	}
-
-	idx, err := remote.Index(referrersRef, remote.WithContext(ctx))
-	if err != nil {
-		return &report.ProvenanceInfo{}, nil
-	}
-
-	manifest, err := idx.IndexManifest()
-	if err != nil || manifest == nil {
-		return &report.ProvenanceInfo{}, nil
-	}
-
-	for _, m := range manifest.Manifests {
-		at := string(m.ArtifactType)
-		// Check artifactType for sigstore bundles
-		if at != "" {
-			predType := m.Annotations["dev.sigstore.bundle.predicateType"]
-			if isSLSAPredicate(predType) {
+	for _, m := range manifests {
+		for _, pt := range predicateTypes(m) {
+			if isSLSAPredicate(pt) {
 				return &report.ProvenanceInfo{
 					HasProvenance: true,
-					PredicateType: predType,
-				}, nil
-			}
-		}
-
-		// Check annotations directly for predicate types
-		for _, v := range m.Annotations {
-			if isSLSAPredicate(v) {
-				return &report.ProvenanceInfo{
-					HasProvenance: true,
-					PredicateType: v,
+					PredicateType: pt,
 				}, nil
 			}
 		}

--- a/internal/verify/provenance.go
+++ b/internal/verify/provenance.go
@@ -44,6 +44,17 @@ func (c *SLSAProvenanceChecker) Check(ctx context.Context, imageRef string) (*re
 		}
 	}
 
+	// BuildKit stores SLSA provenance as an attestation manifest embedded in
+	// the image index (unknown/unknown), not as a referrer, so check there too.
+	for _, pt := range indexAttestationPredicateTypes(ctx, imageRef) {
+		if isSLSAPredicate(pt) {
+			return &report.ProvenanceInfo{
+				HasProvenance: true,
+				PredicateType: pt,
+			}, nil
+		}
+	}
+
 	return &report.ProvenanceInfo{HasProvenance: false}, nil
 }
 

--- a/internal/verify/referrers.go
+++ b/internal/verify/referrers.go
@@ -18,10 +18,19 @@ const (
 	annoInTotoPredicateType   = "in-toto.io/predicate-type"
 )
 
+// Annotation key and value that BuildKit uses to mark the attestation
+// manifests it embeds in a multi-arch image index. Such entries carry platform
+// unknown/unknown and reference the image manifest they attest to.
+const (
+	annoDockerReferenceType = "vnd.docker.reference.type"
+	attestationManifestType = "attestation-manifest"
+)
+
 // referrerManifests resolves imageRef, then reads the OCI referrers index via
 // the <algo>-<hex> fallback tag derived from the image digest, and returns the
-// referring manifest descriptors. Attestations attached by cosign (bundle
-// format) and by docker/build-push-action (sbom/provenance) both land here.
+// referring manifest descriptors. Cosign/sigstore bundle attestations land
+// here. BuildKit's in-index attestation manifests do NOT — those are walked
+// separately by indexAttestationPredicateTypes.
 //
 // Every failure (bad ref, unreachable registry, no referrers tag) returns an
 // empty slice and a nil error: a missing referrers index is the common case,
@@ -74,6 +83,63 @@ func predicateTypes(d v1.Descriptor) []string {
 		}
 		if v != "" {
 			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// indexAttestationPredicateTypes returns the in-toto predicate types attached
+// to imageRef via BuildKit attestation manifests embedded in the image index.
+//
+// docker/build-push-action (sbom: true / provenance: true) and Docker Official
+// Images store SBOM and SLSA attestations as extra manifests inside the
+// multi-arch image index, marked with platform unknown/unknown and the
+// annotation vnd.docker.reference.type=attestation-manifest. The predicate type
+// lives on the attestation manifest's *layer* descriptors, so we fetch each
+// attestation manifest and read its layer annotations. These attestations never
+// appear in the <algo>-<hex> referrers fallback tag, so referrerManifests alone
+// misses them.
+//
+// Every failure returns an empty slice: a single-arch image (no index) or an
+// image without attestations is the common case, not an error worth surfacing.
+func indexAttestationPredicateTypes(ctx context.Context, imageRef string) []string {
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return nil
+	}
+
+	desc, err := remote.Get(ref, remote.WithContext(ctx))
+	if err != nil || !desc.MediaType.IsIndex() {
+		return nil
+	}
+
+	idx, err := desc.ImageIndex()
+	if err != nil {
+		return nil
+	}
+	manifest, err := idx.IndexManifest()
+	if err != nil || manifest == nil {
+		return nil
+	}
+
+	var out []string
+	for _, m := range manifest.Manifests {
+		if m.Annotations[annoDockerReferenceType] != attestationManifestType {
+			continue
+		}
+		attRef := ref.Context().Digest(m.Digest.String())
+		img, err := remote.Image(attRef, remote.WithContext(ctx))
+		if err != nil {
+			continue
+		}
+		attManifest, err := img.Manifest()
+		if err != nil || attManifest == nil {
+			continue
+		}
+		for _, layer := range attManifest.Layers {
+			if pt := layer.Annotations[annoInTotoPredicateType]; pt != "" {
+				out = append(out, pt)
+			}
 		}
 	}
 	return out

--- a/internal/verify/referrers.go
+++ b/internal/verify/referrers.go
@@ -1,0 +1,80 @@
+package verify
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+// Annotation keys that carry the in-toto predicate type of a referring
+// attestation manifest. Sigstore bundles use the first; buildx / BuildKit
+// attestation manifests use the second.
+const (
+	annoSigstorePredicateType = "dev.sigstore.bundle.predicateType"
+	annoInTotoPredicateType   = "in-toto.io/predicate-type"
+)
+
+// referrerManifests resolves imageRef, then reads the OCI referrers index via
+// the <algo>-<hex> fallback tag derived from the image digest, and returns the
+// referring manifest descriptors. Attestations attached by cosign (bundle
+// format) and by docker/build-push-action (sbom/provenance) both land here.
+//
+// Every failure (bad ref, unreachable registry, no referrers tag) returns an
+// empty slice and a nil error: a missing referrers index is the common case,
+// not an error worth surfacing to the caller.
+func referrerManifests(ctx context.Context, imageRef string) ([]v1.Descriptor, error) {
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return nil, nil
+	}
+
+	desc, err := remote.Get(ref, remote.WithContext(ctx))
+	if err != nil {
+		return nil, nil
+	}
+
+	referrersTag := strings.Replace(desc.Digest.String(), ":", "-", 1)
+	referrersRef, err := name.ParseReference(fmt.Sprintf("%s:%s", ref.Context().String(), referrersTag))
+	if err != nil {
+		return nil, nil
+	}
+
+	idx, err := remote.Index(referrersRef, remote.WithContext(ctx))
+	if err != nil {
+		return nil, nil
+	}
+
+	manifest, err := idx.IndexManifest()
+	if err != nil || manifest == nil {
+		return nil, nil
+	}
+
+	return manifest.Manifests, nil
+}
+
+// predicateTypes returns the candidate in-toto predicate types advertised by a
+// referring manifest descriptor: the dedicated sigstore/in-toto annotations
+// first, then every other annotation value as a fallback (some producers stash
+// the predicate type under non-standard keys).
+func predicateTypes(d v1.Descriptor) []string {
+	var out []string
+	if pt := d.Annotations[annoSigstorePredicateType]; pt != "" {
+		out = append(out, pt)
+	}
+	if pt := d.Annotations[annoInTotoPredicateType]; pt != "" {
+		out = append(out, pt)
+	}
+	for k, v := range d.Annotations {
+		if k == annoSigstorePredicateType || k == annoInTotoPredicateType {
+			continue
+		}
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}

--- a/internal/verify/referrers_test.go
+++ b/internal/verify/referrers_test.go
@@ -1,0 +1,68 @@
+package verify
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+func TestPredicateTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		desc v1.Descriptor
+		want []string // membership check, order-independent
+	}{
+		{
+			name: "sigstore bundle annotation",
+			desc: v1.Descriptor{Annotations: map[string]string{
+				annoSigstorePredicateType: "https://slsa.dev/provenance/v1",
+			}},
+			want: []string{"https://slsa.dev/provenance/v1"},
+		},
+		{
+			name: "buildx in-toto annotation",
+			desc: v1.Descriptor{Annotations: map[string]string{
+				annoInTotoPredicateType: "https://spdx.dev/Document",
+			}},
+			want: []string{"https://spdx.dev/Document"},
+		},
+		{
+			name: "non-standard annotation falls through",
+			desc: v1.Descriptor{Annotations: map[string]string{
+				"org.example.predicate": "https://cyclonedx.org/bom",
+			}},
+			want: []string{"https://cyclonedx.org/bom"},
+		},
+		{
+			name: "no annotations",
+			desc: v1.Descriptor{},
+			want: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := predicateTypes(tc.desc)
+			for _, w := range tc.want {
+				if !slices.Contains(got, w) {
+					t.Errorf("predicateTypes() = %v, want to contain %q", got, w)
+				}
+			}
+			if len(tc.want) == 0 && len(got) != 0 {
+				t.Errorf("predicateTypes() = %v, want empty", got)
+			}
+		})
+	}
+}
+
+func TestReferrerManifests_InvalidRef(t *testing.T) {
+	got, err := referrerManifests(context.Background(), ":::invalid")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no manifests for invalid ref, got %d", len(got))
+	}
+}

--- a/internal/verify/sbom.go
+++ b/internal/verify/sbom.go
@@ -25,16 +25,24 @@ func NewSBOMDiscoverer() SBOMDiscoverer {
 }
 
 func (d *OCISBOMDiscoverer) Discover(ctx context.Context, imageRef string) (*report.SBOMInfo, error) {
-	// Primary path: the OCI referrers index. SBOM attestations attached by
-	// docker/build-push-action (sbom: true) and by cosign's bundle format
-	// land here as referring manifests, advertising their format through the
-	// in-toto predicate type. This mirrors how provenance.go finds SLSA
-	// attestations, so the two stay in lock-step.
+	// Path 1: the OCI referrers fallback tag. Cosign/sigstore bundle-format
+	// SBOM attestations land here as referring manifests, advertising their
+	// format through the in-toto predicate type on the descriptor.
 	if info := discoverFromReferrers(ctx, imageRef); info != nil {
 		return info, nil
 	}
 
-	// Fallback: the legacy cosign attestation tag (sha256-<hex>.att) produced
+	// Path 2: BuildKit attestation manifests embedded in the image index.
+	// docker/build-push-action (sbom: true) and Docker Official Images store
+	// the SBOM here, not in the referrers fallback tag, with the predicate type
+	// on the attestation manifest's layers. This is the common case and the
+	// referrers path above cannot see it. provenance.go checks the same place
+	// so the two stay in lock-step.
+	if info := discoverFromIndexAttestations(ctx, imageRef); info != nil {
+		return info, nil
+	}
+
+	// Path 3: the legacy cosign attestation tag (sha256-<hex>.att) produced
 	// by older `cosign attest` runs that predate the referrers/bundle format.
 	if info := discoverFromCosignAtt(imageRef); info != nil {
 		return info, nil
@@ -45,7 +53,7 @@ func (d *OCISBOMDiscoverer) Discover(ctx context.Context, imageRef string) (*rep
 
 // discoverFromReferrers looks for an SBOM attestation in the image's OCI
 // referrers index. Returns nil when no SBOM-typed referrer is found, so the
-// caller can fall through to the legacy path.
+// caller can fall through to the later paths.
 func discoverFromReferrers(ctx context.Context, imageRef string) *report.SBOMInfo {
 	manifests, err := referrerManifests(ctx, imageRef)
 	if err != nil {
@@ -56,6 +64,19 @@ func discoverFromReferrers(ctx context.Context, imageRef string) *report.SBOMInf
 			if format := sbomFormatFromPredicate(pt); format != "" {
 				return &report.SBOMInfo{HasSBOM: true, Format: format}
 			}
+		}
+	}
+	return nil
+}
+
+// discoverFromIndexAttestations looks for an SBOM among the BuildKit
+// attestation manifests embedded in the image index. Returns nil when no
+// SBOM-typed predicate is found, so the caller can fall through to the legacy
+// path.
+func discoverFromIndexAttestations(ctx context.Context, imageRef string) *report.SBOMInfo {
+	for _, pt := range indexAttestationPredicateTypes(ctx, imageRef) {
+		if format := sbomFormatFromPredicate(pt); format != "" {
+			return &report.SBOMInfo{HasSBOM: true, Format: format}
 		}
 	}
 	return nil

--- a/internal/verify/sbom.go
+++ b/internal/verify/sbom.go
@@ -25,24 +25,63 @@ func NewSBOMDiscoverer() SBOMDiscoverer {
 }
 
 func (d *OCISBOMDiscoverer) Discover(ctx context.Context, imageRef string) (*report.SBOMInfo, error) {
+	// Primary path: the OCI referrers index. SBOM attestations attached by
+	// docker/build-push-action (sbom: true) and by cosign's bundle format
+	// land here as referring manifests, advertising their format through the
+	// in-toto predicate type. This mirrors how provenance.go finds SLSA
+	// attestations, so the two stay in lock-step.
+	if info := discoverFromReferrers(ctx, imageRef); info != nil {
+		return info, nil
+	}
+
+	// Fallback: the legacy cosign attestation tag (sha256-<hex>.att) produced
+	// by older `cosign attest` runs that predate the referrers/bundle format.
+	if info := discoverFromCosignAtt(imageRef); info != nil {
+		return info, nil
+	}
+
+	return &report.SBOMInfo{HasSBOM: false}, nil
+}
+
+// discoverFromReferrers looks for an SBOM attestation in the image's OCI
+// referrers index. Returns nil when no SBOM-typed referrer is found, so the
+// caller can fall through to the legacy path.
+func discoverFromReferrers(ctx context.Context, imageRef string) *report.SBOMInfo {
+	manifests, err := referrerManifests(ctx, imageRef)
+	if err != nil {
+		return nil
+	}
+	for _, m := range manifests {
+		for _, pt := range predicateTypes(m) {
+			if format := sbomFormatFromPredicate(pt); format != "" {
+				return &report.SBOMInfo{HasSBOM: true, Format: format}
+			}
+		}
+	}
+	return nil
+}
+
+// discoverFromCosignAtt looks for an SBOM in the legacy cosign attestation tag.
+// Returns nil when nothing usable is found.
+func discoverFromCosignAtt(imageRef string) *report.SBOMInfo {
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {
-		return &report.SBOMInfo{}, nil
+		return nil
 	}
 
 	se, err := ociremote.SignedEntity(ref)
 	if err != nil {
-		return &report.SBOMInfo{}, nil
+		return nil
 	}
 
 	atts, err := se.Attestations()
 	if err != nil {
-		return &report.SBOMInfo{}, nil
+		return nil
 	}
 
 	attList, err := atts.Get()
 	if err != nil || len(attList) == 0 {
-		return &report.SBOMInfo{HasSBOM: false}, nil
+		return nil
 	}
 
 	for _, att := range attList {
@@ -50,16 +89,12 @@ func (d *OCISBOMDiscoverer) Discover(ctx context.Context, imageRef string) (*rep
 		if err != nil {
 			continue
 		}
-		format := detectSBOMFormat(payload)
-		if format != "" {
-			return &report.SBOMInfo{
-				HasSBOM: true,
-				Format:  format,
-			}, nil
+		if format := detectSBOMFormat(payload); format != "" {
+			return &report.SBOMInfo{HasSBOM: true, Format: format}
 		}
 	}
 
-	return &report.SBOMInfo{HasSBOM: false}, nil
+	return nil
 }
 
 // Known in-toto predicate types for SBOM formats.
@@ -67,6 +102,19 @@ const (
 	predicateSPDX      = "https://spdx.dev/Document"
 	predicateCycloneDX = "https://cyclonedx.org/bom"
 )
+
+// sbomFormatFromPredicate maps an in-toto predicate type to an SBOM format,
+// returning "" when the predicate type is not an SBOM.
+func sbomFormatFromPredicate(predicateType string) string {
+	switch {
+	case strings.HasPrefix(predicateType, predicateSPDX):
+		return "spdx"
+	case strings.HasPrefix(predicateType, predicateCycloneDX):
+		return "cyclonedx"
+	default:
+		return ""
+	}
+}
 
 // inTotoStatement represents the minimal structure of an in-toto attestation
 // needed to extract the predicate type.

--- a/internal/verify/sbom_test.go
+++ b/internal/verify/sbom_test.go
@@ -1,6 +1,7 @@
 package verify
 
 import (
+	"context"
 	"testing"
 )
 
@@ -85,6 +86,52 @@ func TestNewSBOMDiscoverer(t *testing.T) {
 	}
 	if _, ok := d.(*OCISBOMDiscoverer); !ok {
 		t.Error("expected *OCISBOMDiscoverer")
+	}
+}
+
+func TestSBOMFormatFromPredicate(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://spdx.dev/Document", "spdx"},
+		{"https://spdx.dev/Document/v2.3", "spdx"},
+		{"https://cyclonedx.org/bom", "cyclonedx"},
+		{"https://cyclonedx.org/bom/v1.5", "cyclonedx"},
+		{"https://slsa.dev/provenance/v1", ""},
+		{"https://in-toto.io/provenance/v1", ""},
+		{"", ""},
+		{"random", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			if got := sbomFormatFromPredicate(tc.input); got != tc.want {
+				t.Errorf("sbomFormatFromPredicate(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOCISBOMDiscoverer_InvalidRef(t *testing.T) {
+	d := NewSBOMDiscoverer()
+	info, err := d.Discover(context.Background(), ":::invalid")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.HasSBOM {
+		t.Error("expected no SBOM for invalid ref")
+	}
+}
+
+func TestOCISBOMDiscoverer_UnreachableImage(t *testing.T) {
+	d := NewSBOMDiscoverer()
+	// Registry calls fail; should return HasSBOM=false without an error.
+	info, err := d.Discover(context.Background(), "localhost:1/nonexistent:v0.0.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.HasSBOM {
+		t.Error("expected no SBOM for unreachable image")
 	}
 }
 


### PR DESCRIPTION
Makes scans actually populate SBOM (and provenance) details. Contains two commits:

1. **`fix(verify): detect SBOMs via OCI referrers index`** (closes #46) — original referrers-fallback-tag discovery.
2. **`fix(verify): detect BuildKit in-index SBOM/provenance attestations`** — closes the gap below.

## Problem

The referrers-index approach detects attestations only via the `<algo>-<hex>` referrers **fallback tag**, which holds cosign/sigstore *bundle* attestations. But `docker/build-push-action` (`sbom: true` / `provenance: true`) and Docker Official Images store SBOM and SLSA attestations as `unknown/unknown` **attestation manifests embedded in the image index**, with the predicate type on the manifest's **layer** annotations (`in-toto.io/predicate-type`).

Those never appear in the fallback tag, so every BuildKit-attached SBOM was silently missed. Verified against a live scan: `imagesWithSBOM: 0` despite e.g. `redis:8.2.3-alpine` shipping an SPDX SBOM.

## Fix

- **`referrers.go`** — new `indexAttestationPredicateTypes()` walks the image index for entries marked `vnd.docker.reference.type=attestation-manifest` and reads each attestation manifest's layer predicate types.
- **`sbom.go`** — added `discoverFromIndexAttestations` as a discovery path (referrers fallback tag → **index attestations** → legacy `.att`).
- **`provenance.go`** — checks index attestations too, so SBOM and provenance stay in lock-step.
- **`buildkit_attest_test.go`** — builds a BuildKit-style index in an in-memory registry and asserts SBOM + provenance detection, plus a no-false-positive guard for provenance-only images.

## Verification

- `go test ./internal/verify/` passes; full module builds.
- Real-registry check with the patched code:

  | Image | Before | After |
  |---|---|---|
  | `redis:8.2.3-alpine` | `SBOM=false` ❌ | `SBOM=true (spdx)` ✅ |
  | `dex:v2.44.0` | `SBOM=false` | `SBOM=false` ✅ (no SBOM present; provenance still detected) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)