### PR TITLE
ci(integration): bump nebari-sandbox action to v2

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Set up Nebari sandbox
         id: sandbox
-        uses: nebari-dev/action-nebari-sandbox@222fcf36fd9a7a6c291f966055a84ad8bb38cfeb # v1.0.3
+        uses: nebari-dev/action-nebari-sandbox@76ffb6ce5dd4141aeccb8c02719c907f0fe9e25e # v2.1.0
         with:
           profile: platform
           cluster-name: provenance-test
@@ -46,12 +46,12 @@ jobs:
           docker build --build-arg VERSION=test -t provenance-collector:test .
           k3d image import provenance-collector:test --cluster provenance-test
 
-      # add-software-pack@v1 (>= v1.0.3) waits for the Application CR to exist
-      # and to reach status.health.status=Healthy by default (wait-for-application
-      # and wait-healthy both default true). It also annotates nebari-root for a
+      # add-software-pack waits for the Application CR to exist and to reach
+      # status.health.status=Healthy by default (wait-for-application and
+      # wait-healthy both default true). It also annotates nebari-root for a
       # refresh internally, so consumers don't need to poll or nudge themselves.
       - name: Register provenance-collector pack
-        uses: nebari-dev/action-nebari-sandbox/add-software-pack@222fcf36fd9a7a6c291f966055a84ad8bb38cfeb # v1.0.3
+        uses: nebari-dev/action-nebari-sandbox/add-software-pack@76ffb6ce5dd4141aeccb8c02719c907f0fe9e25e # v2.1.0
         with:
           gitops-dir: ${{ steps.sandbox.outputs.gitops-dir }}
           app-name: provenance-collector
@@ -250,7 +250,6 @@ jobs:
         if: always()
         run: |
           k3d cluster delete ${{ steps.sandbox.outputs.cluster-name || 'provenance-test' }}
-          docker network rm ${{ steps.sandbox.outputs.network-name }} 2>/dev/null || true
 
       - name: Debug info on failure
         if: failure()


### PR DESCRIPTION
## What

Bumps `nebari-dev/action-nebari-sandbox` from v1.0.3 to v2.1.0 in the integration test workflow, and drops the now-defunct Docker network cleanup line.

## Why

The `integration` job has been failing since 2026-06-19 (last green run 2026-05-29) with `ErrImageNeverPull` on the dashboard pod. It affects `main` and every open PR, e.g. #52:

https://github.com/nebari-dev/provenance-collector/actions/runs/29049823230/job/86230702245

Root cause is a cluster mismatch, not anything in the collector code. On the pinned v1.0.3 action, the `platform` profile deploys NIC through the **local** provider, which stands up a **nested kind cluster** (context `kind-provenance-test`) for the workloads. But the workflow loads the freshly built image into the k3d bootstrap cluster:

```
k3d image import provenance-collector:test --cluster provenance-test
```

So the image lands in k3d while the pods are scheduled on the kind cluster, which never has it. The dashboard runs with `imagePullPolicy: Never` and fails with `ErrImageNeverPull`. The pinned action tag never moved; the breakage came from the platform profile it deploys drifting onto the kind-based local provider.

v2 switches the platform profile to NIC's **existing** provider, which connects to the k3d cluster directly (context `k3d-provenance-test`) instead of creating its own kind cluster (see `feat!: switch platform profile from NIC local to existing provider`, action-nebari-sandbox#57). The image import then targets the same cluster the pods run on, so the existing build-and-load step works unchanged.

## Changes

- `action-nebari-sandbox` and `add-software-pack` pinned to the v2.1.0 commit (`76ffb6c`).
- Removed `docker network rm ${{ steps.sandbox.outputs.network-name }}` from cleanup: v2 removed the `network-name` output since it no longer creates a custom Docker network. This is the only migration step the v2.0.0 notes call out; no input changes are needed for default usage.

## Test plan

CI on this PR is the test - the `integration` job should go green again. Nothing else in the workflow changed.
