### PR TITLE
docs: migrate core README content into Starlight pages

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -28,6 +28,15 @@ export default defineConfig({
           ],
         },
         {
+          label: 'Guides',
+          items: [
+            { label: 'Quick Start', slug: 'quick-start' },
+            { label: 'Architecture', slug: 'architecture' },
+            { label: 'Storage Modes', slug: 'storage-modes' },
+            { label: 'Web Dashboard', slug: 'web-dashboard' },
+          ],
+        },
+        {
           label: 'Reference',
           items: [
             { label: 'Configuration', slug: 'configuration' },
@@ -35,9 +44,6 @@ export default defineConfig({
             { label: 'NebariApp CRD', slug: 'nebariapp-crd-reference' },
           ],
         },
-        // Additional groups (Quick Start, Architecture, Deployment) will be
-        // populated as more of the README and examples/ are migrated into
-        // src/content/docs/.
       ],
     }),
   ],

--- a/docs/src/content/docs/architecture.md
+++ b/docs/src/content/docs/architecture.md
@@ -1,0 +1,66 @@
+---
+title: Architecture
+description: How the collector, dashboard API, frontend, and storage modes fit together.
+---
+
+The Provenance Collector runs as a Kubernetes `CronJob` that discovers what is
+running on the cluster, enriches it with supply-chain data from the container
+registry, and ships a timestamped JSON report to the configured sink.
+
+```mermaid
+flowchart TD
+    Cron[Kubernetes CronJob<br/>default: daily 06:00 UTC]
+    ImgDisc[Image Discovery<br/>pods + workload owners]
+    HelmDisc[Helm Discovery<br/>via Helm SDK]
+    Enrich[Enrichment<br/>digest resolve · cosign verify<br/>SBOM · SLSA · update check]
+    Report[(JSON Provenance Report)]
+    Browser[Browser<br/>React SPA · keycloak-js PKCE]
+    Frontend[Frontend<br/>nginx · serves SPA · proxies /api]
+    Dash[Dashboard API<br/>JSON API · owns the PVC]
+    CM[(ConfigMap<br/>persistence.mode=configmap)]
+    PVC[(Shared PVC<br/>persistence.mode=pvc)]
+    Grafana[Grafana<br/>via Infinity datasource]
+
+    Cron --> ImgDisc
+    Cron --> HelmDisc
+    ImgDisc --> Enrich
+    Enrich --> Report
+    HelmDisc --> Report
+    Report -->|HTTP upload, default| Dash
+    Report -.-> CM
+    Report -.-> PVC
+    PVC -.-> Dash
+    Browser --> Frontend
+    Frontend -->|/api proxy| Dash
+    Dash --> Grafana
+```
+
+The collector reads the Kubernetes API for inventory and the registry for
+enrichment, then ships the report to the dashboard's internal upload endpoint
+(default), a ConfigMap, or a shared PVC depending on `persistence.mode`
+(see [Storage Modes](/storage-modes/)). It does not push to remote services or
+mutate cluster state outside the configured sink. The UI is served separately:
+the browser loads the React SPA from the frontend nginx container, which
+reverse-proxies `/api/*` to the dashboard.
+
+## What it does
+
+| Capability | Description |
+|---|---|
+| **Image Discovery** | Scans all pods across namespaces, deduplicates by workload owner |
+| **Digest Resolution** | Resolves every image tag to its immutable SHA256 digest |
+| **Signature Verification** | Checks for cosign signatures (existence or key-based verification) |
+| **SLSA Provenance** | Detects SLSA provenance attestations via OCI referrers API |
+| **SBOM Detection** | Detects attached SPDX / CycloneDX attestations |
+| **Update Checking** | Compares running tags against latest semver tags (configurable level, pre-release filtering) |
+| **Helm Release Tracking** | Discovers all deployed Helm releases with chart versions |
+| **Web Dashboard** | Optional React + TypeScript SPA (served by nginx) with filters, sorting, pagination, and an image detail drawer |
+| **Grafana Integration** | JSON API compatible with the Infinity datasource for dashboards and alerting |
+| **Provenance Reports** | Outputs timestamped JSON reports via the dashboard's internal upload endpoint (default), a shared PVC, or a ConfigMap, with automatic retention |
+
+## Learn more
+
+- [Quick Start](/quick-start/) — install and run your first scan.
+- [Storage Modes](/storage-modes/) — how reports move from the collector to the dashboard.
+- [Web Dashboard](/web-dashboard/) — the UI, its JSON API, and Grafana integration.
+- [Report Schema](/report-schema/) — the JSON output structure.

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -27,6 +27,13 @@ did it come from, and is it signed?"* should not require manual auditing.
 | **Web dashboard** | Optional UI with filters, sorting, and an image detail panel |
 | **Grafana integration** | JSON API compatible with the Infinity datasource |
 
+## Guides
+
+- [Quick Start](/quick-start/) — install the collector and view your first report.
+- [Architecture](/architecture/) — how the collector, dashboard, and frontend fit together.
+- [Storage Modes](/storage-modes/) — choosing between `http`, `pvc`, and `configmap`.
+- [Web Dashboard](/web-dashboard/) — the UI, its JSON API, and Grafana integration.
+
 ## Reference
 
 - [Configuration](/configuration/) — every environment variable and its chart value.
@@ -36,7 +43,6 @@ did it come from, and is it signed?"* should not require manual auditing.
 > **Status:** Under active development as part of NIC. APIs, chart values, and
 > report schema may change without notice while pre-1.0.
 
-Full installation and deployment instructions live in the
-[project README](https://github.com/nebari-dev/provenance-collector-pack#readme)
-and the [`examples/`](https://github.com/nebari-dev/provenance-collector-pack/tree/main/examples)
-directory. These will be migrated into this site in follow-up changes.
+Additional deployment examples (standalone, Nebari, ArgoCD) live in the
+[`examples/`](https://github.com/nebari-dev/provenance-collector-pack/tree/main/examples)
+directory of the repository.

--- a/docs/src/content/docs/quick-start.md
+++ b/docs/src/content/docs/quick-start.md
@@ -1,0 +1,173 @@
+---
+title: Quick Start
+description: Install the Provenance Collector, trigger a scan, and view your first provenance report.
+---
+
+The Provenance Collector is normally installed by the
+[Nebari Operator](https://github.com/nebari-dev/nebari-operator) as part of
+NIC's foundational software — you don't run any `helm` commands yourself, the
+operator and ArgoCD do it for you. The operator-managed path is the supported
+default; the standalone install below exists for vanilla Kubernetes clusters
+and local development.
+
+## Operator-managed install (default)
+
+A complete ArgoCD `Application` manifest lives at
+[`examples/argocd-application.yaml`](https://github.com/nebari-dev/provenance-collector-pack/blob/main/examples/argocd-application.yaml)
+and is auto-stamped to the latest released chart version on every release.
+Apply it from your gitops repo or directly:
+
+```bash
+kubectl apply -f examples/argocd-application.yaml
+```
+
+The values most users adjust:
+
+```yaml
+nebariapp:
+  enabled: true                       # register the pack with the Nebari Operator
+  hostname: provenance.<your-domain>  # public URL the UI responds on
+
+webUI:
+  enabled: true                       # dashboard API + report-upload endpoint; required when persistence.mode=http
+  features:
+    timelineDeltas: false             # opt-in; show +N/-N badges between scans
+
+frontend:
+  enabled: true                       # standalone React UI (nginx); serves the SPA and proxies /api to the dashboard
+  keycloak:
+    url: https://keycloak.<your-domain>  # required when frontend.enabled: the browser keycloak-js (PKCE) login endpoint
+```
+
+Setting `nebariapp.enabled: true` renders a `NebariApp` custom resource that
+registers the pack with the Nebari Operator. The operator wires up routing,
+provisions a public Keycloak SPA client, and registers the landing page so the
+UI is reachable through the Nebari gateway under `https://<hostname>` and
+surfaced on the [Nebari Landing page](https://github.com/nebari-dev/nebari-landing).
+The React SPA performs the OIDC login in the browser via `keycloak-js` (PKCE);
+the gateway does not enforce auth (`nebariapp.auth.enforceAtGateway: false`).
+Leave `nebariapp.enabled: false` for clusters that aren't running the operator.
+Full field reference: [NebariApp CRD](/nebariapp-crd-reference/).
+
+Verify:
+
+```bash
+# Application picked up by ArgoCD
+kubectl get application provenance-collector -n argocd
+
+# Chart unpacked: CronJob + dashboard pods exist in the target namespace
+kubectl get cronjob -n provenance-system
+kubectl get pods -n provenance-system -l app.kubernetes.io/name=provenance-collector
+```
+
+## Standalone install (without the Nebari Operator)
+
+:::caution
+Use this path only on a vanilla Kubernetes cluster *without* NIC. Without the
+operator you're responsible for routing and OIDC yourself if you want the
+dashboard reachable from outside the cluster.
+:::
+
+### Prerequisites
+
+| Tool | Minimum version | Notes |
+| --- | --- | --- |
+| `kubectl` | 1.26+ | Cluster interaction |
+| `helm` | 3.14+ | Chart install |
+| Kubernetes cluster | 1.26+ | Local (kind / k3d / minikube) or remote |
+| Cluster permissions | `cluster-admin` | Chart creates a `ClusterRole` + `ClusterRoleBinding` |
+
+If you want `nebariapp.enabled: true` on a standalone cluster, the Nebari
+Operator CRDs must still be installed first — see the
+[NebariApp CRD reference](/nebariapp-crd-reference/). Most standalone installs
+leave `nebariapp.enabled: false` and hit the dashboard's JSON API via
+`kubectl port-forward` (the browser UI is the separate `frontend` container —
+see [Web Dashboard](/web-dashboard/)).
+
+### Install
+
+```bash
+helm repo add nebari https://nebari-dev.github.io/helm-repository
+helm repo update
+
+helm install provenance-collector nebari/provenance-collector \
+  --namespace provenance-system \
+  --create-namespace
+```
+
+Or install from a local checkout when iterating on the chart:
+
+```bash
+helm install provenance-collector ./chart \
+  --namespace provenance-system \
+  --create-namespace
+```
+
+### Verify
+
+```bash
+kubectl get cronjob -n provenance-system
+kubectl get pods -n provenance-system -l app.kubernetes.io/name=provenance-collector
+```
+
+### Trigger a manual run
+
+Two options:
+
+1. **From the dashboard** — click the `Run Scan` button next to the timeline.
+   The button only renders for users whose OIDC groups intersect with
+   `webUI.adminGroups`, so it's hidden by default until you wire up
+   `webUI.oidcIssuer` and at least one admin group. Under operator-managed
+   installs (`nebariapp.enabled: true`) this is handled automatically — the
+   operator routes through Keycloak with the groups in `nebariapp.auth.groups`.
+2. **With `kubectl`** — fall back to creating a Job from the CronJob directly:
+
+```bash
+kubectl create job --from=cronjob/provenance-collector \
+  manual-run -n provenance-system
+
+kubectl wait --for=condition=complete job/manual-run \
+  -n provenance-system --timeout=5m
+```
+
+Either path creates a one-shot Job from the same CronJob template, so the
+resulting report is identical. Manual Jobs are auto-cleaned after
+`webUI.manualJobTTL` (default 1h); the kubectl-created Job above has no TTL
+and persists until you delete it.
+
+### View the report
+
+```bash
+# Default (persistence.mode=http) — the dashboard exposes the JSON API (it is
+# API-only; the browser UI is the separate frontend container).
+kubectl port-forward -n provenance-system \
+  svc/provenance-collector-web 8080:8080
+
+# In another shell, fetch the latest JSON:
+curl -s http://localhost:8080/api/reports/latest | jq .
+
+# persistence.mode=configmap — no dashboard required.
+kubectl get configmap provenance-report \
+  -n provenance-system \
+  -o jsonpath='{.data.report\.json}' | jq .
+```
+
+To open the browser UI, use the Nebari gateway (`nebariapp.enabled: true`, at
+`https://<hostname>`) or run it locally against the port-forwarded API — see
+[Web Dashboard](/web-dashboard/). The report's JSON structure is documented in
+the [Report Schema reference](/report-schema/).
+
+### Uninstall
+
+```bash
+helm uninstall provenance-collector -n provenance-system
+
+# Also remove the namespace (and any PVC-stored reports):
+kubectl delete namespace provenance-system
+```
+
+## Next steps
+
+- [Architecture](/architecture/) — how the pieces fit together.
+- [Storage Modes](/storage-modes/) — choosing between `http`, `pvc`, and `configmap`.
+- [Configuration](/configuration/) — every environment variable and chart value.

--- a/docs/src/content/docs/storage-modes.md
+++ b/docs/src/content/docs/storage-modes.md
@@ -1,0 +1,25 @@
+---
+title: Storage Modes
+description: How persistence.mode controls where provenance reports are written and which mode to pick.
+---
+
+`persistence.mode` controls how reports get from the collector Job to the
+dashboard. Pick one:
+
+| Mode | What it does | Use it when |
+|---|---|---|
+| `http` *(default)* | Collector POSTs the JSON to the dashboard's internal Service (`{fullname}-web-internal:8081/internal/reports`, cluster-DNS only). The dashboard pod owns a single PVC; nothing else mounts it. | You're on RWO-only storage (Hetzner `csi.hetzner.cloud`, most cloud CSIs). This is the safe default. |
+| `pvc` | Collector and dashboard share one PVC at `config.reportPath`. `persistence.storageClass` is required and must be ReadWriteMany-capable (Longhorn, NFS, EFS, …) unless every collector pod is guaranteed to land on the same node as the dashboard. The chart fails to render if `storageClass` is empty in this mode. | You already have an RWX-capable storage class and prefer filesystem semantics. |
+| `configmap` | Collector writes the report to a ConfigMap. The dashboard is not used. | Headless / inspection-only installs. |
+
+## Internal upload endpoint
+
+In `http` mode the internal upload endpoint is exposed through a dedicated
+Service (`{fullname}-web-internal`) that the NebariApp / public Ingress never
+references. Apply a NetworkPolicy restricting it to the collector
+ServiceAccount if your cluster supports it.
+
+## Related pages
+
+- [Architecture](/architecture/) — where the storage sink sits in the overall flow.
+- [Configuration](/configuration/) — the `PROVENANCE_REPORT_OUTPUT` variable and related chart values.

--- a/docs/src/content/docs/web-dashboard.md
+++ b/docs/src/content/docs/web-dashboard.md
@@ -1,0 +1,111 @@
+---
+title: Web Dashboard
+description: The React dashboard UI, its JSON API, and how to surface provenance data in Grafana.
+---
+
+The UI is a standalone **React + TypeScript SPA** (Vite + Tailwind + the Nebari
+design system), built into its own nginx image and deployed as a separate
+`Deployment`/`Service`. The Go dashboard is **API-only**: nginx serves the SPA
+and reverse-proxies `/api/*` to the dashboard over cluster DNS. Enable both:
+
+```yaml
+webUI:
+  enabled: true       # dashboard API + report-upload endpoint (required in http mode)
+frontend:
+  enabled: true       # standalone React UI (nginx)
+  keycloak:
+    url: https://keycloak.<your-domain>   # required: the browser keycloak-js login endpoint
+```
+
+The dashboard provides:
+
+- Summary stat cards (`N / M` ratios for Signed, Verified, SLSA, SBOM; absolute counts for Images, Updates, Helm)
+- Report timeline to browse historical reports, with an opt-in `+N / -N` unique-image delta badge between adjacent scans (`webUI.features.timelineDeltas`)
+- Filterable, sortable, paginated image table (truncated workload column with full name on hover)
+- Click any image row for a detail drawer showing signature, SLSA, SBOM, and update info
+- Helm releases table
+- Light / Dark / System theme, chosen from the profile menu (defaults to System)
+- **Run Scan** button — admin-gated; triggers a one-shot Job from the same CronJob template the schedule uses. Hidden unless `webUI.oidcIssuer` is set and the calling user's OIDC groups intersect with `webUI.adminGroups`. Auto-cleanup after `webUI.manualJobTTL` (default 1h).
+- **Export** button (`CSV` / `Markdown` / `JSON`) — downloads whichever report is currently selected on the timeline, not just the latest
+
+## Authentication
+
+The SPA runs the OIDC login in the browser via `keycloak-js` (PKCE), attaching
+the access token to every `/api` call; nginx forwards it to the dashboard,
+which validates it against Keycloak. Under `nebariapp.enabled: true` the
+operator provisions the public SPA client and registers routing/landing-page —
+the gateway itself does **not** enforce auth
+(`nebariapp.auth.enforceAtGateway: false`). The operator also wires
+`webUI.oidcIssuer` / `webUI.adminGroups` from the `nebariapp.auth` block so
+Run Scan lights up for users in the configured groups. See the
+[NebariApp CRD reference](/nebariapp-crd-reference/) for the full field list.
+
+## Running the UI locally
+
+Port-forward the dashboard API and point the Vite dev server at it (auth
+bypassed for local dev):
+
+```bash
+kubectl port-forward svc/provenance-collector-web 8080:8080 -n provenance-system &
+cd frontend
+npm ci
+VITE_DEV_NO_AUTH=true WEBAPI_URL=http://localhost:8080 npm run dev   # → http://localhost:5173
+```
+
+The [`dev/Makefile`](https://github.com/nebari-dev/provenance-collector-pack/tree/main/dev)
+wraps this as `make ui-up` (install the chart, API only) + `make seed`
+(sample reports) + `make ui-dev` (port-forward + Vite).
+
+## Dashboard API
+
+The dashboard exposes a JSON API that the SPA and external tools consume:
+
+| Endpoint | Description |
+|---|---|
+| `GET /api/reports` | List all reports (newest first) with summary |
+| `GET /api/reports/latest` | Get the most recent report |
+| `GET /api/reports/<filename>` | Get a specific report by filename |
+| `GET /api/export?format=csv\|markdown\|md` | Render the selected report as CSV or Markdown. Optional `&filename=<file>` to pin a historical report; defaults to latest. |
+| `GET /api/me` | Calling user's identity + feature flags. Returns `authEnabled`, `canRunScan`, `features.timelineDeltas`. |
+| `POST /api/scan` | Trigger a manual scan Job. 403 if the caller isn't in an admin group, 503 if `PROVENANCE_NAMESPACE` / `PROVENANCE_CRONJOB_NAME` aren't configured. |
+| `GET /healthz` | Health check |
+
+The JSON payloads follow the structure documented in the
+[Report Schema reference](/report-schema/).
+
+## Grafana integration
+
+The provenance data can be surfaced in Grafana using the
+[Infinity datasource](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/)
+plugin, which queries the dashboard's JSON API.
+
+### Setup
+
+1. Enable the web dashboard (`webUI.enabled: true`)
+2. Install the Infinity datasource in Grafana
+3. Add a datasource pointing at the dashboard service:
+   - **URL:** `http://provenance-collector-web.provenance-system.svc:8080`
+   - **Type:** JSON
+
+### Example panels
+
+**Stat panel** (unique images count):
+
+- Type: JSON, URL: `/api/reports/latest`
+- Column: `summary.uniqueImages`
+
+**Images table**:
+
+- Type: JSON, URL: `/api/reports/latest`, Root: `images`
+- Columns: `image`, `namespace`, `signature.signed`, `provenance.hasProvenance`, `update.updateAvailable`
+
+**Alerting** (images with updates):
+
+```
+WHEN count() OF images WHERE updateAvailable = true IS ABOVE 0
+```
+
+An example dashboard (11 panels covering unique images, signature status, SLSA
+provenance, Helm releases, and more) is available at
+[`examples/grafana-dashboard.json`](https://github.com/nebari-dev/provenance-collector-pack/blob/main/examples/grafana-dashboard.json).
+Import it directly into Grafana as a `dashboard.grafana.app/v2beta1` resource.


### PR DESCRIPTION
## Summary

Migrates the highest-value narrative content from the top-level README into proper Starlight pages so the docs site is useful on its own instead of pointing back at the README.

New pages under docs/src/content/docs/:

- quick-start.md - operator-managed (ArgoCD) and standalone Helm install paths, prerequisites, verification, manual scan runs, viewing the report, uninstall
- architecture.md - the mermaid flow diagram (rendered by rehype-mermaid) plus the capability table from "What It Does"
- storage-modes.md - the persistence.mode comparison table (http / pvc / configmap) and the internal upload endpoint note
- web-dashboard.md - dashboard features, authentication, local dev loop, the dashboard JSON API table, and the Grafana Infinity datasource setup

Content was lightly rewritten for a docs-site reader: badges/logo header dropped, "see below" anchors turned into root-absolute links between pages, and repo-file references converted to absolute GitHub URLs.

## Sidebar

- Added a new Guides group in astro.config.mjs between Overview and Reference: Quick Start -> Architecture -> Storage Modes -> Web Dashboard
- index.md now links to the new guide pages and no longer says installation/architecture docs "will be migrated in follow-up changes"

Not touched: configuration.md (generated by hack/gendocs) and anything outside docs/.

## Test plan

- Verified by construction: every page has title + description frontmatter, all internal links use root-absolute slugs with trailing slashes that map to real pages, no relative .md links, and sidebar slugs match filenames
- astro build and scripts/check-links.sh run in CI on Node 22 (local machine is Node 18, which Astro no longer supports)