### PR TITLE
docs(changelog): add 0.1.0 release section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@ First stable release. Supersedes the `0.1.0-alpha.*` pre-releases.
   Deployments/Services, and optional NebariApp CRD integration.
 - Grafana dashboard example wired to the JSON API via the Infinity datasource.
 - Documentation site built with Astro + Starlight and the shared
-  `@nebari/starlight` theme, deployed to GitHub Pages.
+  `@nebari/starlight` theme, deployed to Cloudflare Pages and routed through
+  `packs.nebari.dev/provenance-collector-pack/`, with per-PR previews.
 - SecurityContext hardening (runAsNonRoot, readOnlyRootFilesystem, drop ALL
   capabilities).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,10 @@ First stable release. Supersedes the `0.1.0-alpha.*` pre-releases.
   - Report export as CSV, Markdown, or JSON for the selected report.
   - Admin-gated "Run Scan" button that triggers a one-shot Job from the
     CronJob template, with automatic cleanup of manual Jobs.
-- SBOM (SPDX) and SLSA provenance (`mode=max`) attestations attached to the
-  published collector image on every build, discoverable via the OCI referrers
-  API.
+- Published collector and dashboard images are signed with keyless cosign
+  (Sigstore, via GitHub Actions OIDC - no managed key) and carry SPDX SBOM and
+  SLSA provenance (`mode=max`) attestations, all discoverable via the OCI
+  referrers API. See "Verifying the Collector Image" in the docs.
 - Helm chart: CronJob, RBAC, report storage, dashboard and frontend
   Deployments/Services, and optional NebariApp CRD integration.
 - Grafana dashboard example wired to the JSON API via the Infinity datasource.
@@ -55,10 +56,5 @@ First stable release. Supersedes the `0.1.0-alpha.*` pre-releases.
   attested with older `cosign attest` runs.
 
 ### Known limitations
-- The published collector image ships with SBOM and SLSA provenance
-  attestations but is **not yet cosign-signed**, so when the collector scans
-  its own cluster its image shows as unsigned. Image signing is tracked in #29,
-  deferred pending a decision on the signing trust root (keyless Sigstore vs.
-  key-managed).
 - Air-gapped clusters and private registry mirrors are not yet supported
   (tracked in #1).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-07-13
+
+First stable release. Supersedes the `0.1.0-alpha.*` pre-releases.
+
 ### Added
-- Core provenance collector: image discovery, digest resolution, signature
-  verification, SBOM detection, update checking, and Helm release tracking
-- PVC and ConfigMap report output writers
-- Key-based cosign signature verification using `cosign.VerifyImageSignatures`
-- SBOM format detection via in-toto attestation JSON parsing
-- Optional web dashboard with report timeline, summary stats, image and Helm
-  release tables
-- Helm chart with CronJob, RBAC, PVC, optional web dashboard Deployment/Service,
-  and NebariApp CRD integration
-- CI workflows: lint, test, integration test (kind), image build (GHCR), and
-  release (Helm chart to nebari-dev/helm-repository)
+- Core provenance collector: image discovery, digest resolution, cosign
+  signature verification (keyless and key-based), SBOM detection, SLSA
+  provenance detection, semver update checking, and Helm release tracking.
+- Report output modes selected by `persistence.mode`: HTTP upload to the
+  dashboard's internal endpoint (default, RWO-safe), a shared PVC, or a
+  ConfigMap.
+- Web dashboard: a standalone React + TypeScript SPA (served by nginx) backed
+  by an API-only Go service, with in-browser OIDC login (`keycloak-js`, PKCE).
+  - Summary stat cards, a report timeline with opt-in unique-image delta
+    badges, and a filterable/sortable/paginated image table with a detail
+    drawer.
+  - Report export as CSV, Markdown, or JSON for the selected report.
+  - Admin-gated "Run Scan" button that triggers a one-shot Job from the
+    CronJob template, with automatic cleanup of manual Jobs.
+- SBOM (SPDX) and SLSA provenance (`mode=max`) attestations attached to the
+  published collector image on every build, discoverable via the OCI referrers
+  API.
+- Helm chart: CronJob, RBAC, report storage, dashboard and frontend
+  Deployments/Services, and optional NebariApp CRD integration.
+- Grafana dashboard example wired to the JSON API via the Infinity datasource.
+- Documentation site built with Astro + Starlight and the shared
+  `@nebari/starlight` theme, deployed to GitHub Pages.
 - SecurityContext hardening (runAsNonRoot, readOnlyRootFilesystem, drop ALL
-  capabilities)
+  capabilities).
+
+### Changed
+- README restructured operator-first, with refreshed dashboard sections.
+- Configuration reference is generated from a single source of truth
+  (`internal/configspec`), guarded against drift in CI.
+- Integration test runs on `action-nebari-sandbox` (platform profile, v2)
+  instead of a bare kind cluster.
+- CI actions bumped to Node-24-compatible majors; releases stamp
+  `examples/*.yaml` to the released version.
 
 ### Fixed
-- SBOM detection now reads the OCI referrers index, the same source provenance
-  detection uses, so SBOMs attached by `docker/build-push-action` (`sbom: true`)
-  are discovered and shown in the dashboard. The legacy cosign attestation tag
-  (`.att`) is retained as a fallback for images attested with older `cosign
-  attest` runs.
+- SBOM and SLSA provenance detection now read both the OCI referrers index and
+  BuildKit's in-index attestation manifests, so attestations attached by
+  `docker/build-push-action` are discovered and shown in the dashboard. The
+  legacy cosign attestation tag (`.att`) is retained as a fallback for images
+  attested with older `cosign attest` runs.
+
+### Known limitations
+- The published collector image ships with SBOM and SLSA provenance
+  attestations but is **not yet cosign-signed**, so when the collector scans
+  its own cluster its image shows as unsigned. Image signing is tracked in #29,
+  deferred pending a decision on the signing trust root (keyless Sigstore vs.
+  key-managed).
+- Air-gapped clusters and private registry mirrors are not yet supported
+  (tracked in #1).


### PR DESCRIPTION
## What

Adds a `0.1.0` section to the CHANGELOG in preparation for the first stable release (superseding the `0.1.0-alpha.*` pre-releases).

## How it was built

Consolidates the original core-feature list with every notable change merged since `v0.1.0-alpha.4` (2026-05-14), grouped into Added / Changed / Fixed:

- **Added:** HTTP/PVC/ConfigMap report modes, the standalone React SPA dashboard (export, timeline deltas, admin-gated Run Scan), SBOM + SLSA attestations on the published image, the Grafana example, and the Astro + Starlight docs site.
- **Changed:** operator-first README, generated configuration reference, sandbox-v2 integration CI, Node-24 action bumps.
- **Fixed:** SBOM/provenance detection via OCI referrers + BuildKit in-index attestations.

## Known limitations (deliberate for 0.1.0)

Two notes set expectations explicitly:

- The published image ships **SBOM + SLSA attestations but is not yet cosign-signed** - image signing (#29) is deferred pending the signing-trust-root decision (keyless Sigstore vs key-managed). So the collector's own row shows attestations present, signature absent.
- Air-gapped / private-registry-mirror support is not yet available (#1).

## Notes

- The date is set to `2026-07-13`; bump it if the tag lands on a different day.
- No release is cut by this PR - it only prepares the changelog. Tagging `0.1.0` is a separate, explicit step.
- Content is a judgment call - happy to re-weight what's emphasized or trim.
