### PR TITLE
ci(image): sign published images with keyless cosign (closes #29)

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -42,6 +42,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # keyless cosign signing via GitHub OIDC
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -50,6 +51,11 @@ jobs:
       # out with "Attestation is not supported for the docker driver."
       - name: Set up Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v3.1.1'
 
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -90,6 +96,7 @@ jobs:
           fi
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
@@ -106,6 +113,21 @@ jobs:
           sbom: true
           provenance: mode=max
 
+      # Keyless cosign signature over the pushed digest, in both registries.
+      # Uses the workflow's OIDC identity (no secret / no managed key); this is
+      # the last "grey" supply-chain signal on our own image (#29). Skipped on
+      # PRs, which have no durable published artifact worth signing.
+      - name: Sign images (keyless)
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          COSIGN_YES: "true"
+        run: |
+          for repo in "ghcr.io/${{ github.repository }}" "quay.io/nebari/provenance-collector"; do
+            echo "Signing ${repo}@${DIGEST}"
+            cosign sign "${repo}@${DIGEST}"
+          done
+
   # The standalone React UI ships as its own nginx image. It has no third-party
   # registry mirror (unlike the Go image on Quay), so it publishes to GHCR only.
   build-frontend:
@@ -116,11 +138,17 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # keyless cosign signing via GitHub OIDC
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v3.1.1'
 
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -143,6 +171,7 @@ jobs:
             type=ref,event=pr
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: frontend
@@ -152,3 +181,13 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           sbom: true
           provenance: mode=max
+
+      - name: Sign image (keyless)
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          COSIGN_YES: "true"
+        run: |
+          repo="ghcr.io/${{ github.repository }}/frontend"
+          echo "Signing ${repo}@${DIGEST}"
+          cosign sign "${repo}@${DIGEST}"

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -42,6 +42,7 @@ export default defineConfig({
             { label: 'Configuration', slug: 'configuration' },
             { label: 'Report Schema', slug: 'report-schema' },
             { label: 'NebariApp CRD', slug: 'nebariapp-crd-reference' },
+            { label: 'Verifying Images', slug: 'verifying-images' },
           ],
         },
       ],

--- a/docs/src/content/docs/verifying-images.md
+++ b/docs/src/content/docs/verifying-images.md
@@ -1,0 +1,42 @@
+---
+title: Verifying the Collector Image
+description: Verify the cosign signature, SLSA provenance, and SBOM attached to the published provenance-collector images.
+---
+
+The published collector and dashboard-frontend images are signed with **keyless
+cosign** (Sigstore) using the release workflow's GitHub Actions OIDC identity -
+there are no long-lived signing keys. Every build also attaches an SPDX SBOM and
+a SLSA provenance attestation as OCI referrers.
+
+## Verify the signature
+
+Requires [cosign](https://docs.sigstore.dev/) v3+. **Identity pinning is
+mandatory**: without `--certificate-identity-regexp` and
+`--certificate-oidc-issuer`, cosign would accept a signature from any identity,
+which defeats the purpose.
+
+```bash
+cosign verify \
+  --certificate-identity-regexp '^https://github.com/nebari-dev/provenance-collector-pack/\.github/workflows/build-image\.yaml@refs/tags/v.*$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  quay.io/nebari/provenance-collector:0.1.0
+```
+
+The same digest is published to GHCR - swap the reference to verify it, or the
+dashboard UI image:
+
+- `ghcr.io/nebari-dev/provenance-collector-pack:0.1.0`
+- `ghcr.io/nebari-dev/provenance-collector-pack/frontend:0.1.0`
+
+A successful run prints the verified certificate's identity and OIDC issuer.
+
+## Inspect the SBOM and provenance
+
+```bash
+cosign tree quay.io/nebari/provenance-collector:0.1.0
+```
+
+This lists the attached SPDX SBOM and SLSA provenance attestations. The
+collector detects these same referrers when it scans a cluster, which is why
+its own image shows **Signed / SBOM / SLSA** in the dashboard rather than the
+grey "no provenance" state.


### PR DESCRIPTION
## What

Closes the last open half of #29: **sign the published images**. The collector and frontend images already carry an SPDX SBOM and a SLSA provenance attestation (`sbom: true`, `provenance: mode=max`); this adds a **keyless cosign signature** over each pushed digest so the images stop showing the grey "no signature" state when the collector scans its own cluster.

## Approach (matches the ecosystem)

This follows the keyless-Sigstore posture Chuck established for NIC's release pipeline in `nebari-dev/nebari-infrastructure-core#476` ("harden the release pipeline - signing, SBOM, provenance, SHA pins"), which settled the trust-root question:

- **Keyless cosign** via `sigstore/cosign-installer` (cosign v3.1.1), signing with the workflow's **GitHub Actions OIDC identity** - no long-lived key, no secret.
- Trust root is public-good Sigstore (Fulcio/Rekor) + the `https://token.actions.githubusercontent.com` issuer.
- Verification is documented with **mandatory identity pinning** (`--certificate-identity-regexp` + `--certificate-oidc-issuer`).

NIC signs `checksums.txt` (a Go/GoReleaser artifact); we sign the container image digests instead - same decision, image-appropriate mechanic.

## Changes

- **`.github/workflows/build-image.yaml`**: add `id-token: write` to both jobs, install cosign, and `cosign sign <repo>@<digest>` the pushed digest - both registries (ghcr + quay) for the collector, ghcr for the frontend. Signing runs on `push`/`release`/`dispatch`; PRs still build+push but skip signing (no durable artifact, and cleaner OIDC surface).
- **`docs/src/content/docs/verifying-images.md`** (+ sidebar): how to `cosign verify` with identity pinning, plus `cosign tree` for the SBOM/provenance.

## Notes / verification

- **No new secrets** - keyless uses OIDC. Quay accepts the cosign signature as a generic OCI artifact.
- Signing only produces artifacts on a real `push`/`release` (it needs the workflow OIDC identity), so it can't be exercised on this PR or locally. Recommend confirming on the first `main` merge (or a `v0.1.0-rc` tag) that `cosign verify ... quay.io/nebari/provenance-collector:<tag>` succeeds per the new doc, then that the dashboard shows the collector's own row as Signed.
- Once merged, the #57 CHANGELOG "Known limitations" note about the image being unsigned should be dropped if this lands in 0.1.0.
