### PR TITLE
docs(changelog): set 0.1.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - 2026-07-13
+## [0.1.0] - 2026-07-15
 
 First stable release. Supersedes the `0.1.0-alpha.*` pre-releases.
 


### PR DESCRIPTION
Stamp the 0.1.0 CHANGELOG heading with the actual release date (2026-07-15) ahead of cutting the tag.