### PR TITLE
chore(ci): adopt shared reusable build+sign workflow (migration plan)

### DIFF
--- a/hack/checkimage/main.go
+++ b/hack/checkimage/main.go
@@ -1,0 +1,81 @@
+// checkimage runs the collector's own signature / SBOM / SLSA-provenance
+// detection against one or more image references and prints the result as JSON.
+//
+// It calls the exact internal/verify code paths the collector uses at scan
+// time, so it validates supply-chain detection directly against a registry -
+// no cluster, no CronJob, and no dashboard UI. Use it to confirm that an image
+// the collector *should* recognize as signed/attested actually comes back that
+// way (for example, when a build pipeline changes how it attaches SBOM and
+// provenance).
+//
+// Usage:
+//
+//	go run ./hack/checkimage <image-ref> [<image-ref> ...]
+//
+// Example:
+//
+//	go run ./hack/checkimage \
+//	  quay.io/nebari/provenance-collector:0.1.0 \
+//	  ghcr.io/nebari-dev/provenance-collector-pack:0.1.0
+//
+// If PROVENANCE_COSIGN_PUBLIC_KEY is set, signature verification uses that key;
+// otherwise it only checks for signature existence (matching the collector's
+// default behaviour).
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/nebari-dev/provenance-collector/internal/report"
+	"github.com/nebari-dev/provenance-collector/internal/verify"
+)
+
+type result struct {
+	Image      string                 `json:"image"`
+	Signature  *report.SignatureInfo  `json:"signature"`
+	SBOM       *report.SBOMInfo       `json:"sbom"`
+	Provenance *report.ProvenanceInfo `json:"provenance"`
+}
+
+func main() {
+	images := os.Args[1:]
+	if len(images) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: checkimage <image-ref> [<image-ref> ...]")
+		os.Exit(2)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	sigVerifier := verify.NewSignatureVerifier(os.Getenv("PROVENANCE_COSIGN_PUBLIC_KEY"))
+	sbomDiscoverer := verify.NewSBOMDiscoverer()
+	provChecker := verify.NewProvenanceChecker()
+
+	results := make([]result, 0, len(images))
+	for _, img := range images {
+		sig, err := sigVerifier.Verify(ctx, img)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warn: signature verify %s: %v\n", img, err)
+		}
+		sbom, err := sbomDiscoverer.Discover(ctx, img)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warn: sbom discover %s: %v\n", img, err)
+		}
+		prov, err := provChecker.Check(ctx, img)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warn: provenance check %s: %v\n", img, err)
+		}
+		results = append(results, result{Image: img, Signature: sig, SBOM: sbom, Provenance: prov})
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(results); err != nil {
+		fmt.Fprintln(os.Stderr, "encode:", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
**Draft / blocked on `nebari-dev/.github#46`.** Opening now to hold the plan and the validation tooling.

## Goal

Retire this repo's bespoke `build-image.yaml` (inline keyless cosign + buildx `sbom`/`provenance` from #59) and adopt the org's shared reusable build+sign workflow once `nebari-dev/.github#46` lands. This converges our image supply-chain with `llm-serving-pack` / `nebari-frames`:

- Signing + attestation move into the shared `sign-oci` composite action (keyless cosign + `attest-build-provenance` + `attest-sbom`).
- The cosign **signer identity becomes the shared-workflow identity** (`nebari-dev/.github/.github/workflows/pack-build-image.yaml@<ref>`, via `job_workflow_ref`), the same for every pack, instead of our per-repo `build-image.yaml@refs/tags/v.*`.

## Migration checklist

- [ ] `nebari-dev/.github#46` (reusable `sign-oci`/`sign-blob`) merges and is proven on `llm-serving-pack`.
- [ ] Replace `build-image.yaml`'s two inline jobs with calls to `nebari-dev/.github/.github/workflows/pack-build-image.yaml@<pinned-sha>` (collector + frontend images).
- [ ] Drop the inline cosign step and the buildx `sbom: true` / `provenance: mode=max` (the shared `sign-oci` action does both).
- [ ] Update `docs/src/content/docs/verifying-images.md` to pin the **shared-workflow** identity, aligned with Chuck's `verifying-nebari-artifacts.md`.
- [ ] Validate detection with `hack/checkimage` against a shared-workflow-built image (see below).

## Included now: `hack/checkimage`

A small tool that runs the collector's own `internal/verify` detectors (signature, SBOM, provenance) against arbitrary image refs and prints JSON - the same code path used at scan time, no cluster or dashboard needed. This is the acceptance harness for the migration: after the switch, an image the collector should see as signed/attested must still come back that way.

```
go run ./hack/checkimage quay.io/nebari/provenance-collector:0.1.0
```

## Finding: signature detection misses modern cosign signatures

Running `checkimage` against the signed `0.1.0` images returned `signature.signed: false` for all three - even though `cosign verify` passes on every one. Root cause: `internal/verify/cosign.go` `checkExistence` uses `ociremote.SignedEntity(ref).Signatures()`, the legacy cosign `.sig` tag, and misses modern keyless (bundle/referrers) signatures. Same class of bug as the SBOM issue fixed in #48. This undercuts #29 (our own image still shows unsigned in the dashboard), so it needs its own fix - tracking separately. It also feeds the open question of whether our SBOM/provenance referrers detection needs the real referrers API rather than only the `<algo>-<hex>` fallback tag once packs sign via `sign-oci`.

Related: `nebari-dev/.github#46`.
