### PR TITLE
fix(verify): detect keyless cosign signatures via OCI referrers (closes #62)

### DIFF
--- a/internal/verify/cosign.go
+++ b/internal/verify/cosign.go
@@ -46,7 +46,7 @@ func (v *CosignVerifier) Verify(ctx context.Context, imageRef string) (*report.S
 	}
 
 	// Otherwise, just check for signature existence.
-	return v.checkExistence(ref)
+	return v.checkExistence(ctx, ref)
 }
 
 // verifyWithKey performs full key-based cosign signature verification.
@@ -93,26 +93,24 @@ func (v *CosignVerifier) verifyWithKey(ctx context.Context, ref name.Reference) 
 }
 
 // checkExistence checks whether any cosign signature exists for the image
-// without verifying against a specific key.
-func (v *CosignVerifier) checkExistence(ref name.Reference) (*report.SignatureInfo, error) {
-	se, err := ociremote.SignedEntity(ref)
-	if err != nil {
-		return &report.SignatureInfo{
-			Error: fmt.Sprintf("fetching signed entity: %v", err),
-		}, nil
+// without verifying against a specific key. It looks in two places: the legacy
+// sha256-<digest>.sig tag (older cosign), and the OCI referrers index (modern
+// keyless cosign, which attaches the signature as a sigstore-bundle referrer).
+func (v *CosignVerifier) checkExistence(ctx context.Context, ref name.Reference) (*report.SignatureInfo, error) {
+	// Legacy path: the sha256-<digest>.sig tag.
+	if se, err := ociremote.SignedEntity(ref); err == nil {
+		if sigs, err := se.Signatures(); err == nil {
+			if sigList, err := sigs.Get(); err == nil && len(sigList) > 0 {
+				return &report.SignatureInfo{Signed: true}, nil
+			}
+		}
 	}
 
-	sigs, err := se.Signatures()
-	if err != nil {
-		return &report.SignatureInfo{
-			Error: fmt.Sprintf("checking signatures: %v", err),
-		}, nil
+	// Modern path: a signature attached as an OCI referrer (bundle format),
+	// which the legacy .sig-tag lookup does not see.
+	if hasSignatureReferrer(ctx, ref.Name()) {
+		return &report.SignatureInfo{Signed: true}, nil
 	}
 
-	sigList, err := sigs.Get()
-	if err != nil || len(sigList) == 0 {
-		return &report.SignatureInfo{Signed: false}, nil
-	}
-
-	return &report.SignatureInfo{Signed: true}, nil
+	return &report.SignatureInfo{Signed: false}, nil
 }

--- a/internal/verify/referrers.go
+++ b/internal/verify/referrers.go
@@ -144,3 +144,42 @@ func indexAttestationPredicateTypes(ctx context.Context, imageRef string) []stri
 	}
 	return out
 }
+
+// artifactType prefix of a cosign/sigstore signature stored in the modern
+// bundle format. Keyless `cosign sign` (v3+) attaches the signature as an OCI
+// referrer with this artifactType (e.g. ...bundle.v0.3+json) rather than at the
+// legacy sha256-<digest>.sig tag.
+const sigstoreBundleArtifactType = "application/vnd.dev.sigstore.bundle"
+
+// hasSignatureReferrer reports whether imageRef has a cosign/sigstore signature
+// attached via the OCI referrers API. This is the modern bundle-format
+// signature, which ociremote.SignedEntity (the legacy .sig tag) does not see.
+//
+// Uses remote.Referrers (the real referrers API) rather than the <algo>-<hex>
+// fallback tag, since a registry may serve referrers only through the API.
+// Any failure (bad ref, unreachable registry, no referrers) returns false: an
+// image without a signature referrer is the common case, not an error.
+func hasSignatureReferrer(ctx context.Context, imageRef string) bool {
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return false
+	}
+	desc, err := remote.Get(ref, remote.WithContext(ctx))
+	if err != nil {
+		return false
+	}
+	idx, err := remote.Referrers(ref.Context().Digest(desc.Digest.String()), remote.WithContext(ctx))
+	if err != nil {
+		return false
+	}
+	manifest, err := idx.IndexManifest()
+	if err != nil || manifest == nil {
+		return false
+	}
+	for _, m := range manifest.Manifests {
+		if strings.HasPrefix(string(m.ArtifactType), sigstoreBundleArtifactType) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/verify/referrers_test.go
+++ b/internal/verify/referrers_test.go
@@ -66,3 +66,16 @@ func TestReferrerManifests_InvalidRef(t *testing.T) {
 		t.Errorf("expected no manifests for invalid ref, got %d", len(got))
 	}
 }
+
+func TestHasSignatureReferrer_InvalidRef(t *testing.T) {
+	if hasSignatureReferrer(context.Background(), ":::invalid") {
+		t.Error("expected false for invalid ref")
+	}
+}
+
+func TestHasSignatureReferrer_UnreachableImage(t *testing.T) {
+	// Registry call fails; must return false without panicking.
+	if hasSignatureReferrer(context.Background(), "localhost:1/nonexistent:v0.0.0") {
+		t.Error("expected false for unreachable image")
+	}
+}


### PR DESCRIPTION
Fixes #62.

## Problem

The collector reported `signature.signed: false` for images signed with modern keyless cosign, even though `cosign verify` passes. `internal/verify/cosign.go` `checkExistence` only read the legacy `sha256-<digest>.sig` tag (`ociremote.SignedEntity().Signatures()`); cosign v3 attaches the signature as an OCI **referrer** (sigstore bundle, `artifactType application/vnd.dev.sigstore.bundle.v0.3+json`), which that lookup never sees. Same class as the SBOM-detection gap fixed in #48.

## Fix

- Add `hasSignatureReferrer` (in `referrers.go`): resolve the image digest, query the **referrers API** (`remote.Referrers`), and match a referrer whose `artifactType` starts with `application/vnd.dev.sigstore.bundle`.
- `checkExistence` now tries the legacy `.sig` tag first, then falls back to the referrers check. Legacy-signed images keep working; modern keyless-signed images are now detected.
- Uses the real referrers API (not the `<algo>-<hex>` fallback tag) since a registry may serve referrers only through the API.

## Verification

Ran the collector's own detectors (via `hack/checkimage` from #61) against the published `0.1.0` images, before and after:

| image | before | after |
|---|---|---|
| `quay.io/nebari/provenance-collector:0.1.0` | `signed: false` | `signed: true` |
| `ghcr.io/.../provenance-collector-pack:0.1.0` | `signed: false` | `signed: true` |
| `ghcr.io/.../frontend:0.1.0` | `signed: false` | `signed: true` |

`verified: false` is expected here (keyless existence check, no public key configured). Added graceful-failure unit tests for the new helper; `go test ./internal/verify` and `golangci-lint` are clean.

## Note

This only touches existence detection (`checkExistence`, the default keyless path). Key-based `verifyWithKey` is unchanged. The broader question of whether SBOM/provenance detection should also move to the referrers API (rather than the fallback tag) is tracked with the shared-workflow migration in #61.
