### PR TITLE
Fix page load error when no reports

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,9 +49,6 @@ function CenteredMessage({ children }: { children: React.ReactNode }) {
 
 export default function App() {
   const me = useMe();
-  // The listing endpoint returns JSON `null` (not `[]`) when no scans exist yet,
-  // and a destructuring default only fills in for `undefined` — so coalesce
-  // explicitly, otherwise reports[0]/reports.length below throw on a fresh install.
   const { data, isLoading: reportsLoading, isError } = useReports();
   const reports = data ?? [];
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,7 +49,11 @@ function CenteredMessage({ children }: { children: React.ReactNode }) {
 
 export default function App() {
   const me = useMe();
-  const { data: reports = [], isLoading: reportsLoading, isError } = useReports();
+  // The listing endpoint returns JSON `null` (not `[]`) when no scans exist yet,
+  // and a destructuring default only fills in for `undefined` — so coalesce
+  // explicitly, otherwise reports[0]/reports.length below throw on a fresh install.
+  const { data, isLoading: reportsLoading, isError } = useReports();
+  const reports = data ?? [];
 
   const [active] = useAtom(activeReportFilenameAtom);
   const activeFilename = active ?? reports[0]?.filename ?? null;

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -111,7 +111,9 @@ func (s *Server) handleListReports(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
-	var reports []reportEntry
+	// Initialize non-nil so an empty reports dir encodes as `[]`, not `null` — a
+	// JSON null would slip past the frontend's list handling and crash the render.
+	reports := []reportEntry{}
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") || e.Name() == "provenance-latest.json" {
 			continue

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -121,8 +121,13 @@ func TestListReports_EmptyDir(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &reports); err != nil {
 		t.Fatalf("failed to unmarshal: %v", err)
 	}
-	if reports != nil {
-		t.Errorf("expected null/empty, got %d reports", len(reports))
+	// An empty reports dir must encode as `[]`, not `null`, so the frontend's
+	// list handling doesn't choke on a null body.
+	if reports == nil {
+		t.Error("expected an empty array, got null")
+	}
+	if len(reports) != 0 {
+		t.Errorf("expected 0 reports, got %d", len(reports))
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [x] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
