### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-07-21
+
+### Added
+- Dashboard branding and theming support: the logo, title, and theme colors
+  can be customized through chart values and are injected into the frontend at
+  runtime (no rebuild required).
+
+### Fixed
+- Web dashboard no longer errors on page load when there are no reports yet;
+  the empty state renders cleanly on a fresh install.
+
 ## [0.1.0] - 2026-07-15
 
 First stable release. Supersedes the `0.1.0-alpha.*` pre-releases.

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   resolves digests, verifies signatures, checks for updates, and generates
   compliance-grade provenance reports.
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "0.1.1"
 home: https://github.com/nebari-dev/nebari-provenance-collector-pack
 sources:
   - https://github.com/nebari-dev/nebari-provenance-collector-pack


### PR DESCRIPTION
## Summary

Prepares the `0.1.1` release. Bumps the chart `version`/`appVersion` and adds the CHANGELOG entry covering everything landed since `v0.1.0`.

### Changes since v0.1.0
- **Added** — dashboard branding & theming support (#64): logo, title, and theme colors customizable via chart values, injected into the frontend at runtime.
- **Fixed** — page-load error when there are no reports yet (#65); the empty state now renders cleanly on a fresh install.

## Cutting the release

After merge, publish a GitHub Release with tag `v0.1.1` to trigger `.github/workflows/release.yaml` (packages + publishes the Helm chart to the nebari helm-repository, syncs OCI, stamps examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)