### PR TITLE
fix(frontend): restore data:image URIs in sanitizeUrl

### DIFF
--- a/frontend/src/app/config.test.ts
+++ b/frontend/src/app/config.test.ts
@@ -140,7 +140,7 @@ describe("loadAppConfig URL sanitisation", () => {
     expect(cfg.faviconUrl).toBe("http://example.com/favicon.ico");
   });
 
-  it("drops javascript:/data: and malformed URLs", async () => {
+  it("drops javascript:, data:text/html, non-base64 data: images, and malformed URLs", async () => {
     const cfg = await loadWith({
       keycloak: { url: "u", realm: "r", clientId: "c" },
       logoUrl: "javascript:alert(1)",
@@ -150,5 +150,23 @@ describe("loadAppConfig URL sanitisation", () => {
     expect(cfg.logoUrl).toBeUndefined();
     expect(cfg.logoUrlDark).toBeUndefined();
     expect(cfg.faviconUrl).toBeUndefined();
+  });
+
+  it("drops data:text/html even when base64-encoded", async () => {
+    const cfg = await loadWith({
+      keycloak: { url: "u", realm: "r", clientId: "c" },
+      logoUrl: "data:text/html;base64,PHNjcmlwdD4=",
+    });
+    expect(cfg.logoUrl).toBeUndefined();
+  });
+
+  it("keeps base64-encoded data: image URIs from the allow-list", async () => {
+    const cfg = await loadWith({
+      keycloak: { url: "u", realm: "r", clientId: "c" },
+      logoUrl: "data:image/png;base64,iVBORw0KGgo=",
+      faviconUrl: "data:image/svg+xml;base64,PHN2Zy8+",
+    });
+    expect(cfg.logoUrl).toBe("data:image/png;base64,iVBORw0KGgo=");
+    expect(cfg.faviconUrl).toBe("data:image/svg+xml;base64,PHN2Zy8+");
   });
 });

--- a/frontend/src/app/config.ts
+++ b/frontend/src/app/config.ts
@@ -67,9 +67,22 @@ export function safeCssValue(value: string | undefined): string | undefined {
   return value && !UNSAFE_CSS.test(value) ? value : undefined;
 }
 
-// Accept only non-empty, well-formed http(s) URLs or root-relative paths;
-// anything else (including "") becomes undefined so a bad config value can't
-// land in an <img src> or <link href>.
+// Image MIME types accepted as inline data: URIs (only when base64-encoded).
+const ALLOWED_DATA_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/jpg",
+  "image/svg+xml",
+  "image/webp",
+  "image/gif",
+  "image/x-icon",
+  "image/vnd.microsoft.icon",
+]);
+
+// Accept only non-empty, well-formed http(s) URLs, root-relative paths, or
+// base64-encoded data: image URIs from the allow-list above; anything else
+// (including "") becomes undefined so a bad config value can't land in an
+// <img src> or <link href>.
 function sanitizeUrl(value: string | undefined): string | undefined {
   if (!value) {
     return undefined;
@@ -79,7 +92,21 @@ function sanitizeUrl(value: string | undefined): string | undefined {
   }
   try {
     const { protocol } = new URL(value);
-    return protocol === "http:" || protocol === "https:" ? value : undefined;
+    if (protocol === "http:" || protocol === "https:") {
+      return value;
+    }
+    if (protocol === "data:") {
+      // Only accept base64-encoded images whose MIME type is on the allow-list;
+      // reject data:text/html, non-base64 payloads, and anything else.
+      const match = value.match(/^data:([^;,]+)(;base64)?,/);
+      if (!match) {
+        return undefined;
+      }
+      const mime = match[1].toLowerCase();
+      const isBase64 = Boolean(match[2]);
+      return isBase64 && ALLOWED_DATA_MIME_TYPES.has(mime) ? value : undefined;
+    }
+    return undefined;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Regression

`sanitizeUrl()` in `frontend/src/app/config.ts` validates deployer-supplied branding image URLs (`logoUrl`, `logoUrlDark`, `faviconUrl`). It accepted only `http(s)` URLs and root-relative paths, so valid inline `data:image/*;base64,...` URIs were silently **dropped**. This broke deployers who embed logos/favicons inline as base64.

## The fix

Add an allow-list of safe image MIME types and expand `sanitizeUrl()` to handle the `data:` protocol: a `data:` URI is preserved only when it is **base64-encoded** AND its MIME type is on the allow-list. Everything else — `javascript:`, `data:text/html` (even base64), non-base64 `data:image/...`, and malformed values — still resolves to `undefined`.

Allow-listed MIME types: `image/png`, `image/jpeg`, `image/jpg`, `image/svg+xml`, `image/webp`, `image/gif`, `image/x-icon`, `image/vnd.microsoft.icon`.

## Test changes

`frontend/src/app/config.test.ts`:
- Kept assertions that `javascript:`, `data:text/html`, non-base64 `data:image/svg+xml,<svg/>`, and malformed values become `undefined`.
- Added a case asserting `data:text/html;base64,...` is still dropped.
- Added a case asserting valid base64 `data:image/png` and `data:image/svg+xml` URIs are now **preserved**.

## Test plan

- [x] `npx vitest run` — 52 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check src/app/config.ts` — clean

Backports nebari-dev/nebari-landing#173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)