### PR TITLE
chore(frontend): migrate to the renamed @base-ui/react package

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "provenance-collector-frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@base-ui-components/react": "^1.0.0-rc.0",
+        "@base-ui/react": "^1.6.0",
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource/ibm-plex-mono": "^5.2.7",
         "@tailwindcss/vite": "^4.3.0",
@@ -546,19 +546,16 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@base-ui-components/react": {
-      "version": "1.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@base-ui-components/react/-/react-1.0.0-rc.0.tgz",
-      "integrity": "sha512-9lhUFbJcbXvc9KulLev1WTFxS/alJRBWDH/ibKSQaNvmDwMFS2gKp1sTeeldYSfKuS/KC1w2MZutc0wHu2hRHQ==",
-      "deprecated": "Package was renamed to @base-ui/react",
+    "node_modules/@base-ui/react": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
+      "integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@base-ui-components/utils": "0.2.2",
-        "@floating-ui/react-dom": "^2.1.6",
-        "@floating-ui/utils": "^0.2.10",
-        "reselect": "^5.1.1",
-        "tabbable": "^6.3.0",
+        "@babel/runtime": "^7.29.2",
+        "@base-ui/utils": "0.3.1",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
         "use-sync-external-store": "^1.6.0"
       },
       "engines": {
@@ -569,26 +566,33 @@
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
         "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
         "react": "^17 || ^18 || ^19",
         "react-dom": "^17 || ^18 || ^19"
       },
       "peerDependenciesMeta": {
+        "@date-fns/tz": {
+          "optional": true
+        },
         "@types/react": {
+          "optional": true
+        },
+        "date-fns": {
           "optional": true
         }
       }
     },
-    "node_modules/@base-ui-components/utils": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@base-ui-components/utils/-/utils-0.2.2.tgz",
-      "integrity": "sha512-rNJCD6TFy3OSRDKVHJDzLpxO3esTV1/drRtWNUpe7rCpPN9HZVHUCuP+6rdDYDGWfXnQHbqi05xOyRP2iZAlkw==",
-      "deprecated": "Package was renamed to @base-ui/utils",
+    "node_modules/@base-ui/utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
+      "integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@floating-ui/utils": "^0.2.10",
-        "reselect": "^5.1.1",
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.11",
+        "reselect": "^5.2.0",
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
@@ -8320,12 +8324,6 @@
         "type": "Buy me a coffee",
         "url": "https://www.buymeacoffee.com/systeminfo"
       }
-    },
-    "node_modules/tabbable": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
-      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
-      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "test": "vitest --run"
   },
   "dependencies": {
-    "@base-ui-components/react": "^1.0.0-rc.0",
+    "@base-ui/react": "^1.6.0",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource/ibm-plex-mono": "^5.2.7",
     "@tailwindcss/vite": "^4.3.0",

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,4 +1,4 @@
-import { useRender } from "@base-ui-components/react/use-render";
+import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,4 +1,4 @@
-import { useRender } from "@base-ui-components/react/use-render";
+import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
 import { Children, isValidElement, type ReactNode } from "react";
 import { Spinner } from "@/components/ui/spinner";

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,4 +1,4 @@
-import { Dialog as DialogPrimitive } from "@base-ui-components/react/dialog";
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { XIcon } from "lucide-react";
 import type * as React from "react";
 import { Button } from "@/components/ui/button";

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,4 +1,4 @@
-import { Input as InputPrimitive } from "@base-ui-components/react/input";
+import { Input as InputPrimitive } from "@base-ui/react/input";
 import { TriangleAlert } from "lucide-react";
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,4 +1,4 @@
-import { Select as SelectPrimitive } from "@base-ui-components/react/select";
+import { Select as SelectPrimitive } from "@base-ui/react/select";
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 import type * as React from "react";
 import { cn } from "@/lib/utils";


### PR DESCRIPTION
## Summary

`@base-ui-components/react` is [deprecated on npm](https://www.npmjs.com/package/@base-ui-components/react) — *"Package was renamed to `@base-ui/react`"* — and frozen at `1.0.0-rc.0`. The Nebari design system registry already migrated, so every component we pull from `@nebari` is authored against `@base-ui/react`.

This swaps `frontend`'s dependency to `@base-ui/react` ^1.6.0 and updates the five import specifiers.

## Changes

- `package.json`: `@base-ui-components/react@^1.0.0-rc.0` → `@base-ui/react@^1.6.0`
- Import specifier updated in `ui/button.tsx`, `ui/badge.tsx`, `ui/dialog.tsx`, `ui/input.tsx`, `ui/select.tsx`

No API changes were needed — the rename is source-compatible for the primitives this app uses (`useRender`, `Dialog`, `Input`, `Select`).

## Verification

- `npm run build` — clean
- `npm test` — 5 files, 52 tests passing
- `npm run check` (biome) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)