### PR TITLE
fix(ci): move pack to the nebari-apps ArgoCD project (v0.10.0 default is deny-all)

### DIFF
--- a/.github/argo-apps/provenance-collector.yaml
+++ b/.github/argo-apps/provenance-collector.yaml
@@ -4,7 +4,11 @@ metadata:
   name: provenance-collector
   namespace: argocd
 spec:
-  project: default
+  # Software packs must run under the `nebari-apps` project. As of NIC v0.10.0
+  # the `default` project is deny-all (empty sourceRepos + resource whitelists),
+  # so an Application on `default` never renders and sits at Unknown/Unknown.
+  # `nebari-apps` permits the file:// gitops source and all resource kinds.
+  project: nebari-apps
   source:
     repoURL: "file://${GITOPS_DIR}"
     targetRevision: HEAD

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -275,14 +275,18 @@ jobs:
           path: docs/screenshots/
           if-no-files-found: ignore
 
-      - name: Cleanup
-        if: always()
-        run: |
-          k3d cluster delete ${{ steps.sandbox.outputs.cluster-name || 'provenance-test' }}
-
+      # Runs BEFORE Cleanup: the cluster must still exist for these kubectl
+      # calls to return anything. (Previously this ran after Cleanup, so every
+      # command hit a torn-down cluster and captured nothing.)
       - name: Debug info on failure
         if: failure()
         run: |
+          echo "=== Pack Application ==="
+          kubectl get applications -n argocd \
+            -o custom-columns='NAME:.metadata.name,SYNC:.status.sync.status,HEALTH:.status.health.status' || true
+          kubectl get application/provenance-collector -n argocd \
+            -o jsonpath='{.status.conditions}{"\n"}' || true
+          echo ""
           echo "=== Pods ==="
           kubectl get pods -A
           echo ""
@@ -302,3 +306,8 @@ jobs:
           echo ""
           echo "=== Events ==="
           kubectl get events --sort-by=.lastTimestamp | tail -30
+
+      - name: Cleanup
+        if: always()
+        run: |
+          k3d cluster delete ${{ steps.sandbox.outputs.cluster-name || 'provenance-test' }}


### PR DESCRIPTION
## What

The integration test's pack Application ran under `project: default`. NIC **v0.10.0** redefined the `default` ArgoCD project as **deny-all** (empty `sourceRepos` and empty cluster/namespace resource whitelists), so the Application never rendered and sat at `Unknown / Unknown` until `add-software-pack`'s `wait-healthy` timed out after 5m.

The sandbox step pins the action to a SHA but not `nic-version`, so the action installs `nic latest` at runtime. Once v0.10.0 released (2026-07-17) every run silently started picking it up - which is why the integration test has failed on every run since (07-21, 07-23, 07-27), with no change to the pack code itself.

## Fix

- `.github/argo-apps/provenance-collector.yaml`: `project: default` -> `project: nebari-apps`. Software packs must run under `nebari-apps`, which permits the `file://${GITOPS_DIR}` gitops source (it is the platform `GitRepoURL`) and whitelists all resource kinds/namespaces.
- `.github/workflows/test-integration.yaml`: move `Debug info on failure` to run **before** `Cleanup`. It previously ran after `Cleanup` deleted the k3d cluster, so every `kubectl` hit a torn-down cluster (`connection refused`) and captured nothing. It now also dumps the pack Application's sync/health and conditions - the diagnostic that was missing here.

## Evidence

Failing run: https://github.com/nebari-dev/provenance-collector-pack/actions/runs/30260650959/job/89959473512 - Application `provenance-collector` reached `Unknown / Unknown` and `wait-healthy` timed out. `Chart.yaml` committed fine, so this was not a chart/render problem; it was the project scoping.

The v0.10.0 project scheme (deny-all `default`, packs on `nebari-apps`) is documented in NIC's `docs/operations/argocd-project-scoping.md` ("Software pack Applications must set `project: nebari-apps`").

## Follow-up suggestion (not in this PR)

Consider pinning `nic-version` on the sandbox step so a future NIC release can't silently break this again - at the cost of having to bump it deliberately to pick up fixes.
