### PR TITLE
chore: enable Dependabot for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "08:00"
+      timezone: "US/Eastern"
+    groups:
+      # Group all patch and minor updates into a single PR
+      patch-and-minor:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+    # Major updates are not grouped, so each opens its own PR
+    ignore:
+      # Stay on @types/node 24.x to match the Node 24 runtime target.
+      - dependency-name: "@types/node"
+        versions: [">=25"]
+
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "08:00"
+      timezone: "US/Eastern"
+    groups:
+      # Group all patch and minor updates into a single PR
+      patch-and-minor:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+    # Major updates are not grouped, so each opens its own PR
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "08:00"
+      timezone: "US/Eastern"
+    groups:
+      # Group all GitHub Actions updates into a single PR
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml`, modeled on the config in [nebari-design](https://github.com/nebari-dev/nebari-design/blob/main/.github/dependabot.yml).

## What's covered

| Ecosystem | Directory |
| --- | --- |
| npm | `/frontend` |
| npm | `/docs` |
| github-actions | `/` |

The Python backend is intentionally **not** covered.

## Behavior

- Monthly checks, Mondays at 08:00 US/Eastern.
- Patch and minor updates are grouped into a single PR per ecosystem; majors are ungrouped so each gets its own PR and can be reviewed on its own.
- `@types/node` is held at 24.x to match the Node 24 runtime target.

## Test plan

- [x] `dependabot.yml` parses as valid YAML.
- [ ] After merge, confirm Dependabot picks up the config under Insights → Dependency graph → Dependabot with no config errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)