### PR TITLE
fix(ci): keep Dependabot PRs from failing on unavailable secrets

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,17 +8,31 @@ updates:
       time: "08:00"
       timezone: "US/Eastern"
     groups:
-      # Group all patch and minor updates into a single PR
+      # vite, its plugins, and vitest are locked together by peer ranges:
+      # @vitejs/plugin-react 6 needs vite ^8, so a lone plugin bump can't
+      # install. Group them with majors included so the toolchain moves as one.
+      vite-toolchain:
+        applies-to: version-updates
+        patterns:
+          - "vite"
+          - "@vitejs/*"
+          - "vitest"
+          - "@vitest/*"
+      # Group all remaining patch and minor updates into a single PR
       patch-and-minor:
         applies-to: version-updates
         update-types:
           - "minor"
           - "patch"
-    # Major updates are not grouped, so each opens its own PR
+    # Other major updates are not grouped, so each opens its own PR
     ignore:
       # Stay on @types/node 24.x to match the Node 24 runtime target.
       - dependency-name: "@types/node"
         versions: [">=25"]
+      # TypeScript 7 drops `baseUrl` and non-relative path mappings, both of
+      # which tsconfig.app.json relies on. Upgrade deliberately, not via a bot.
+      - dependency-name: "typescript"
+        versions: [">=7"]
 
   - package-ecosystem: "npm"
     directory: "/docs"

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -8,6 +8,11 @@ on:
 
 jobs:
   sync:
+    # Dependabot PRs run against a separate secrets store, so
+    # ADD_TO_PROJECT_PAT is empty and the sync fails on an unauthenticated
+    # `gh api` call. Dependency bumps don't belong on the project board
+    # anyway, so skip them.
+    if: github.actor != 'dependabot[bot]'
     uses: nebari-dev/.github/.github/workflows/sync-project-priority.yaml@main
     with:
       project-id: PVT_kwDOBd3CI84BKoKt

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -36,9 +36,15 @@ jobs:
     # Fork PRs can't read QUAY_USERNAME/QUAY_PASSWORD secrets and would fail at
     # the login step. Skip them entirely; the Test/lint workflows still verify
     # the Dockerfile builds via `docker build` in the integration job.
+    #
+    # Dependabot PRs need the same treatment for a different reason: their
+    # branches live in this repo, so the fork check above passes, but GitHub
+    # runs them against a separate Dependabot secrets store, leaving the Quay
+    # secrets empty. Match on the actor instead.
     if: >-
       github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]')
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

Enabling Dependabot (#71) made **all 7** bot PRs fail. Two separate causes, neither of them the dependency bumps themselves.

## Cause 1 — secrets are empty in Dependabot PRs

Dependabot's branches live in this repo, so the existing fork guards evaluate to `true`, but GitHub runs `pull_request` events from Dependabot against a **separate Dependabot secrets store**. Regular Actions secrets arrive empty:

- **`build-image` / `build-and-push`** — died at the Quay login with `Username and password required`. The guard only checked `head.repo.full_name == github.repository`, which a Dependabot branch satisfies. Widened to also exclude the bot actor.
- **`add-to-project` / `sync`** — died on an unauthenticated `gh api` call (`GH_TOKEN:` empty, `ADD_TO_PROJECT_PAT` unavailable). Dependency bumps don't belong on the project board, so the job is skipped for the bot.

`build-frontend` and `docs` were already fine — verified on #73, where both passed.

## Cause 2 — two majors that can never go green as isolated bumps

- **`@vitejs/plugin-react` 6** (#75) requires `vite@^8` while we're on vite 7, so `npm ci` fails with `ERESOLVE`. The vite toolchain is now grouped (`vite`, `@vitejs/*`, `vitest`, `@vitest/*`) with majors included, so it moves as one installable PR.
- **`typescript` 7** (#76) removes `baseUrl` and non-relative path mappings, both of which `frontend/tsconfig.app.json` still uses (`error TS5102`, `error TS5090`). Held at `<7` so that migration is deliberate rather than a bot PR that can't pass.

## Effect on the open Dependabot PRs

| PR | Was failing on | After this |
| --- | --- | --- |
| #72 docs patch-and-minor | `sync` | ✅ green |
| #73 frontend patch-and-minor | `sync`, `build-and-push` | ✅ green |
| #74 github-actions group | `sync`, `build-and-push` | ✅ green |
| #77 jsdom 30 | `sync`, `build-and-push` | ✅ green |
| #78 lucide-react 1.28 | `sync`, `build-and-push` | ✅ green |
| #75 @vitejs/plugin-react 6 | real `ERESOLVE` | close; returns grouped with vite 8 |
| #76 typescript 7 | real `TS5102` | close; now ignored |

The five in the first block need a rebase (comment `@dependabot rebase`) after this merges to pick up the workflow changes.

## Test plan

- [x] All three files parse as valid YAML.
- [ ] Merge, `@dependabot rebase` on #72–#74 / #77 / #78, confirm green.
- [ ] Close #75 and #76.
- [ ] Confirm `build-and-push` still runs on pushes to `main` (the guard's `github.event_name != 'pull_request'` arm is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)