### PR TITLE
fix(frontend): derive hover and sidebar tokens from --primary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Dashboard branding: overriding `frontend.branding.theme.*.primary` now also
+  rebrands button/badge hover and active states and the sidebar tokens.
+  `--primary-hover`, `--sidebar-primary`, `--sidebar-primary-foreground` and
+  `--sidebar-ring` were hard-coded to the Nebari magenta, so a rebranded
+  dashboard flashed magenta on hover. They are now derived from `--primary`,
+  `--primary-foreground` and `--ring`, and are additionally documented as
+  overridable tokens (`primaryHover`, `sidebarPrimary`,
+  `sidebarPrimaryForeground`, `sidebarRing`).
+
 ## [0.1.1] - 2026-07-21
 
 ### Added

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -149,9 +149,18 @@ frontend:
     # CSS variable overrides injected at runtime — no image rebuild required.
     # Values are validated in the browser and rejected if they contain CSS
     # injection characters (';', '{', '}', quotes, url(), javascript:, etc.).
-    # Supported tokens: primary, primaryForeground, background, foreground,
-    # secondary, secondaryForeground, muted, mutedForeground, accent,
-    # accentForeground, border, ring, radius.
+    # Supported tokens: primary, primaryForeground, primaryHover, background,
+    # foreground, secondary, secondaryForeground, muted, mutedForeground,
+    # accent, accentForeground, border, ring, radius, sidebarPrimary,
+    # sidebarPrimaryForeground, sidebarRing.
+    # primaryHover, sidebarPrimary, sidebarPrimaryForeground and sidebarRing are
+    # derived from primary / primaryForeground / ring by the SPA's stylesheet —
+    # setting primary alone rebrands hover and sidebar states too. Set them only
+    # to pin a specific shade.
+    # Keys are passed through to CSS as-is (no allow-list is enforced at deploy
+    # or at runtime), so any other theme variable the SPA defines can be set
+    # here — but only the tokens above are supported and covered by compatibility
+    # guarantees.
     # Example:
     #   theme:
     #     light:

--- a/docs/src/content/docs/web-dashboard.md
+++ b/docs/src/content/docs/web-dashboard.md
@@ -56,10 +56,21 @@ React mounts (title, favicon, and theme CSS variables) and in the header (logo).
 | `logoUrl` | Header logo (light mode / default). Absolute `http(s)` URL or root-relative path. |
 | `logoUrlDark` | Dark-mode header logo. Falls back to `logoUrl`, then the built-in dark logo. |
 | `faviconUrl` | Favicon URL. |
-| `theme.light` / `theme.dark` | CSS variable overrides per mode. Supported tokens: `primary`, `primaryForeground`, `background`, `foreground`, `secondary`, `secondaryForeground`, `muted`, `mutedForeground`, `accent`, `accentForeground`, `border`, `ring`, `radius`. |
+| `theme.light` / `theme.dark` | CSS variable overrides per mode. Supported tokens: `primary`, `primaryForeground`, `primaryHover`, `background`, `foreground`, `secondary`, `secondaryForeground`, `muted`, `mutedForeground`, `accent`, `accentForeground`, `border`, `ring`, `radius`, `sidebarPrimary`, `sidebarPrimaryForeground`, `sidebarRing`. |
 
 Every field is optional. Any field left empty uses the built-in Nebari default,
 so an unbranded install looks exactly as it does today.
+
+`primaryHover` (the button/badge hover and active shade), `sidebarPrimary`,
+`sidebarPrimaryForeground` and `sidebarRing` are derived from `primary`,
+`primaryForeground` and `ring` in the stylesheet, so setting `primary` is enough
+to rebrand hover and sidebar states as well. Override them explicitly only to
+pin a specific shade.
+
+Token keys are written to CSS as-is — no allow-list is enforced when the chart
+renders `config.json` or when the SPA applies it — so any other theme variable
+the SPA defines can technically be set here. Only the tokens listed above are
+supported.
 
 ### Kubernetes / Helm
 

--- a/frontend/src/app/config.test.ts
+++ b/frontend/src/app/config.test.ts
@@ -88,6 +88,26 @@ describe("applyAppConfig", () => {
     expect(css).toContain("--primary: #4da6ff;");
   });
 
+  it("kebab-cases multi-word tokens such as primaryHover and sidebarPrimary", () => {
+    applyAppConfig(
+      baseConfig({
+        theme: {
+          light: {
+            primaryHover: "#004c99",
+            sidebarPrimary: "#0066cc",
+            sidebarPrimaryForeground: "#ffffff",
+            sidebarRing: "#3399ff",
+          },
+        },
+      }),
+    );
+    const css = document.querySelector("style[data-branding]")?.textContent ?? "";
+    expect(css).toContain("--primary-hover: #004c99;");
+    expect(css).toContain("--sidebar-primary: #0066cc;");
+    expect(css).toContain("--sidebar-primary-foreground: #ffffff;");
+    expect(css).toContain("--sidebar-ring: #3399ff;");
+  });
+
   it("drops unsafe theme token values while keeping safe ones", () => {
     applyAppConfig(
       baseConfig({

--- a/frontend/src/app/config.ts
+++ b/frontend/src/app/config.ts
@@ -20,11 +20,22 @@
  * `primaryForeground`). Applied at runtime as the kebab-case CSS custom
  * property `--primary-foreground`, scoped to `:root` (light) or `.dark`.
  * Mirrors the tokens documented as overridable in the chart's values.yaml.
+ *
+ * `primaryHover`, `sidebarPrimary`, `sidebarPrimaryForeground` and
+ * `sidebarRing` are derived from `primary` / `primaryForeground` / `ring` in
+ * index.css, so overriding `primary` alone already rebrands them; they are
+ * listed here for deployers who want to pin a specific shade instead.
+ *
+ * Note this is a compile-time type only: it is erased at runtime, and
+ * `toCssVars()` below applies whatever keys the config actually carries. Any
+ * token in index.css can therefore be overridden — but only the documented ones
+ * are supported.
  */
 export type ThemeTokens = Partial<
   Record<
     | "primary"
     | "primaryForeground"
+    | "primaryHover"
     | "background"
     | "foreground"
     | "secondary"
@@ -35,7 +46,10 @@ export type ThemeTokens = Partial<
     | "accentForeground"
     | "border"
     | "ring"
-    | "radius",
+    | "radius"
+    | "sidebarPrimary"
+    | "sidebarPrimaryForeground"
+    | "sidebarRing",
     string
   >
 >;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -12,7 +12,15 @@
    the Nebari brand palette for light and dark modes — treat them as
    upstream-managed and re-pull via `shadcn add @nebari/theme` rather than
    hand-tuning. App-specific status / pill / text-secondary tokens (which the
-   Nebari theme does not ship) are layered on top of each block. */
+   Nebari theme does not ship) are layered on top of each block.
+
+   Exception: the tokens marked "derived from --primary" below are deliberately
+   expressed in terms of --primary / --primary-foreground / --ring instead of the
+   literal Nebari oklch values. Deployers rebrand at runtime by overriding
+   --primary (frontend.branding.theme in the chart -> /config.json -> a <style>
+   block appended to <head>), and a literal would keep painting Nebari magenta
+   on hover / in the sidebar under a non-magenta brand. Keep them derived when
+   re-pulling the theme. */
 
 :root {
   --radius: 0.625rem;
@@ -29,7 +37,12 @@
 
   --primary: oklch(55.06% 0.1886 311.45);
   --primary-foreground: oklch(100% 0 0);
-  --primary-hover: oklch(47.01% 0.1577 311.26);
+  /* derived from --primary: the Nebari light hover step is a ~15% darkening of
+     --primary, so mix towards black instead of hard-coding the shade. Mixed in
+     oklab (not oklch) because black/white are achromatic and would drag the hue
+     during polar interpolation. Renders as #77379a against the default
+     --primary, vs #77399a for the literal it replaces. */
+  --primary-hover: color-mix(in oklab, var(--primary), black 15%);
 
   --secondary: oklch(95.04% 0.0042 236.5);
   --secondary-foreground: oklch(32.95% 0.0209 254.12);
@@ -63,12 +76,13 @@
 
   --sidebar: oklch(97.91% 0 0);
   --sidebar-foreground: oklch(26.94% 0.0037 286.15);
-  --sidebar-primary: oklch(55.06% 0.1886 311.45);
-  --sidebar-primary-foreground: oklch(100% 0 0);
+  /* derived from --primary / --ring (matches nebari-landing's index.css) */
+  --sidebar-primary: var(--primary);
+  --sidebar-primary-foreground: var(--primary-foreground);
   --sidebar-accent: oklch(95.04% 0.0042 236.5);
   --sidebar-accent-foreground: oklch(32.95% 0.0209 254.12);
   --sidebar-border: oklch(78.06% 0.0056 286.27);
-  --sidebar-ring: oklch(61.98% 0.2159 311.67);
+  --sidebar-ring: var(--ring);
 
   /* Motion tokens */
   --duration-fast: 100ms;
@@ -118,7 +132,11 @@
 
   --primary: oklch(61.98% 0.2159 311.67);
   --primary-foreground: oklch(0% 0 0);
-  --primary-hover: oklch(69.98% 0.1926 311.48);
+  /* derived from --primary: dark mode lightens on hover instead of darkening.
+     Renders as #bf76e9 against the default --primary, vs #c575f4 for the
+     literal it replaces (dE_ok 0.019, under one JND) — mixing towards white
+     cannot raise chroma the way the hand-picked literal did. */
+  --primary-hover: color-mix(in oklab, var(--primary), white 18%);
 
   --secondary: oklch(40% 0.0269 250.57);
   --secondary-foreground: oklch(95.04% 0.0042 236.5);
@@ -152,12 +170,13 @@
 
   --sidebar: oklch(26.94% 0.0037 286.15);
   --sidebar-foreground: oklch(97.91% 0 0);
-  --sidebar-primary: oklch(61.98% 0.2159 311.67);
-  --sidebar-primary-foreground: oklch(0% 0 0);
+  /* derived from --primary / --ring (matches nebari-landing's index.css) */
+  --sidebar-primary: var(--primary);
+  --sidebar-primary-foreground: var(--primary-foreground);
   --sidebar-accent: oklch(40% 0.0269 250.57);
   --sidebar-accent-foreground: oklch(95.04% 0.0042 236.5);
   --sidebar-border: oklch(47.01% 0.0112 285.96);
-  --sidebar-ring: oklch(69.98% 0.1926 311.48);
+  --sidebar-ring: var(--ring);
 
   /* App-specific tokens (not part of the Nebari theme) */
   --body-background: #262628;


### PR DESCRIPTION
## The defect

The chart advertises runtime rebranding: `frontend.branding.theme.{light,dark}` is rendered into `/config.json` and applied by `frontend/src/app/config.ts` as a `<style>` block appended to `<head>` before React mounts. Overriding `primary` is meant to be all a deployer needs to do.

But `frontend/src/index.css` also hard-coded four tokens to the Nebari magenta (oklch hue ~311), none of which are reachable from an override of `primary`:

| token | light | dark |
|---|---|---|
| `--primary-hover` | L32 | L121 |
| `--sidebar-primary` | L66 | L155 |
| `--sidebar-primary-foreground` | L67 | L156 |
| `--sidebar-ring` | L71 | L160 |

**User-visible symptom:** a dashboard rebranded to any non-purple `primary` renders correctly at rest, then flashes the old Nebari magenta on *every* button and badge hover/active state — `hover:bg-primary-hover` / `active:bg-primary-hover` in `components/ui/button.tsx` and `components/ui/badge.tsx`. Observed on a live cluster.

## The fix

- `--sidebar-primary`, `--sidebar-primary-foreground` and `--sidebar-ring` become plain aliases of `--primary` / `--primary-foreground` / `--ring`. This is what [`nebari-landing`'s `index.css`](https://github.com/nebari-dev/nebari-landing) already does for the sidebar primary pair.
- `--primary-hover` can't be a pure alias — it's a *darker* shade in light mode and a *lighter* one in dark — so it becomes a `color-mix()` off `--primary`:
  - light: `color-mix(in oklab, var(--primary), black 15%)`
  - dark: `color-mix(in oklab, var(--primary), white 18%)`

  Mixed in **oklab**, not oklch as one might expect: `black`/`white` are achromatic, and interpolating hue against them in a polar space drags the result off-hue. Oklab is rectangular, so the hue is preserved exactly and the mix is a clean scale of L and chroma.
- `primaryHover`, `sidebarPrimary`, `sidebarPrimaryForeground` and `sidebarRing` are added to the documented token list (`ThemeTokens` in `config.ts`, the chart's `values.yaml` comment, and `docs/web-dashboard.md`), so pinning an explicit shade instead of taking the derived one stays supported.

### Honest contract

A second, subtler problem: `ThemeTokens` is a compile-time type, erased at runtime. `toCssVars()` iterates `Object.entries(tokens)` with no allow-list, and the chart passes the theme map straight through `toJson` with no `values.schema.json`. Undocumented keys have therefore always reached CSS — the documented contract and the real one disagreed, and deployers may already be relying on that. Rather than break them by adding an allow-list, the docs and the `values.yaml` comment now state that keys pass through as-is and that only the listed tokens are supported. (Value sanitisation is unchanged: `safeCssValue()` still rejects CSS-injection characters.)

## Default appearance

The derived defaults were checked against the literals they replace, in Chrome:

| | before | after | ΔE<sub>ok</sub> |
|---|---|---|---|
| light hover | `#77399a` | `#77379a` | 0.003 |
| dark hover | `#c575f4` | `#bf76e9` | 0.019 |

Light is indistinguishable. Dark is ~0.019, under one JND — mixing towards white can't *raise* chroma the way the hand-picked literal did (it was L +0.08 *and* C −0.023 relative to `--primary`), so this is the closest a derivation gets without hard-coding a hue again. Side-by-side swatches render as the same purple.

`index.css` carries a header comment saying the theme block is upstream-managed and should be re-pulled via `shadcn add @nebari/theme` rather than hand-tuned. That comment now has an explicit exception for these tokens, so a future re-pull doesn't silently revert the fix.

## Verification

Run from a clean clone of this branch:

- `npm ci && npm run check` (Biome) — exit 0; `npm run ci` — exit 0. The 3 warnings / 2 infos are pre-existing on `main` (`PageHeader.tsx` suppression).
- `npm test` — 6 files, 59 tests passed, including a new case asserting the kebab-casing of `primaryHover` → `--primary-hover` and `sidebarPrimaryForeground` → `--sidebar-primary-foreground`.
- `npm run build` — built. Lightning CSS emits a graceful fallback for browsers without `color-mix()`: `--primary-hover: var(--primary)` plus an `@supports (color: color-mix(in lab, red, red))` override. Worst case a very old browser gets hover == primary, never the wrong brand colour.
- `go build ./...`, `go test ./...` — all packages pass.
- `helm lint chart/`, `helm template` (default and NebariApp variants) — pass. `go run ./hack/checkenvs`, `go run ./hack/gendocs --check` — pass.
- End-to-end against the **built** bundle in headless Chrome, with a `<style data-branding>` block simulating what `applyAppConfig()` injects (`--primary: #0066cc` light / `#4da6ff` dark):

  ```
  LIGHT  --primary #0066cc  --primary-hover color-mix(in oklab, #0066cc, black 15%)  --sidebar-primary #0066cc
  DARK   --primary #4da6ff  --primary-hover color-mix(in oklab, #4da6ff, white 18%)  --sidebar-primary #4da6ff
  ```

  i.e. a single `primary` override now propagates. Before this change both hover values stayed magenta.
- `helm template` with `theme.light.primaryHover` / `theme.dark.sidebarRing` set confirms the new keys reach the rendered `config.json`.

## Related

`nebari-llm-serving-pack` has the byte-identical defect (the two `index.css` files appear to share an origin) and is getting a parallel PR. The two fixes should stay consistent — if the `color-mix` percentages or the oklab-vs-oklch choice are revised here, please revise them there too.
