### PR TITLE
ci(release): move the release tag onto the stamp commit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,6 +104,8 @@ jobs:
   # and examples/*.yaml (so users who copy them aren't pinned to a stale chart
   # revision). Runs after the chart is published; commits the rewritten files
   # back to main with [skip ci] so the bump doesn't trigger another release.
+  # Finally moves the release tag onto the stamp commit, since the tag was cut
+  # before the stamp existed and would otherwise carry the previous version.
   stamp-version:
     name: Stamp release version onto main
     runs-on: ubuntu-latest
@@ -137,6 +139,8 @@ jobs:
           git diff chart/Chart.yaml examples/ || true
 
       - name: Commit and push to main
+        env:
+          TAG: ${{ github.event.release.tag_name }}
         run: |
           if git diff --quiet chart/Chart.yaml examples/; then
             echo "Nothing needed updating."
@@ -145,5 +149,19 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add chart/Chart.yaml examples/
-          git commit -m "chore: stamp version to ${{ github.event.release.tag_name }} [skip ci]"
+          git commit -m "chore: stamp version to ${TAG} [skip ci]"
           git push
+          # The release tag was cut from main before this commit existed, so
+          # its tree still carries the previous version. Move it onto the
+          # stamp commit so the tag (and the release's source archives) shows
+          # the released version — but only when the tag is this commit's
+          # direct parent, so the tag can never pick up unrelated commits
+          # that landed on main in the meantime.
+          git fetch origin "refs/tags/${TAG}" --no-tags
+          if [ "$(git rev-parse 'FETCH_HEAD^{commit}')" = "$(git rev-parse HEAD^)" ]; then
+            git tag -f "${TAG}" HEAD
+            git push --force origin "refs/tags/${TAG}"
+            echo "Moved ${TAG} to $(git rev-parse HEAD)."
+          else
+            echo "::warning::main moved past ${TAG} before stamping; leaving the tag where it is."
+          fi


### PR DESCRIPTION
## Summary
- The release tag is created at publish time, before the `stamp-version` job commits the new version to main — so the tag's tree (and the release's source archives) still carried the previous release's version. (The published chart tarball was unaffected; `publish-helm-chart` stamps its own checkout before packaging.)
- After pushing the stamp commit, the job now moves the release tag onto it (`git tag -f` + a force-push of just that tag ref).

## Safeguards
- Retags only when the old tag commit is the stamp commit's direct parent, so the tag can never sweep in unrelated commits that landed on main between publish and stamp; otherwise it emits a workflow warning and leaves the tag alone.
- No workflow in this repo triggers on tag pushes, and this workflow only fires on `release: published`, so moving the tag ref can't re-trigger anything.

Note: v0.1.4 was already fixed manually with the equivalent retag (`df55858` → `ae7a6e1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)