### PR TITLE
ci: migrate the integration test to action-nebari-sandbox v3

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -73,9 +73,39 @@ jobs:
           chart-source: ./chart
           application-manifest: .github/argo-apps/provenance-collector.yaml
 
+      # add-software-pack's wait-healthy is not enough on its own: ArgoCD
+      # aggregates an Application with zero live resources to Healthy, so it
+      # returns as soon as the Application object exists — here that was 0.3s
+      # after creation, before a single manifest had synced. And `kubectl wait`
+      # exits NotFound immediately on a missing object (its --timeout never
+      # applies), so a condition-wait that runs too early fails in 0s rather
+      # than waiting. Wait for the chart's objects to actually exist first.
+      - name: Wait for the chart's objects to sync
+        run: |
+          for obj in \
+            deployment/provenance-test-provenance-collector-web \
+            cronjob/provenance-test-provenance-collector; do
+            echo "Waiting for ArgoCD to create $obj..."
+            for i in $(seq 1 60); do
+              if kubectl get "$obj" >/dev/null 2>&1; then
+                echo "  $obj exists (attempt $i)"
+                break
+              fi
+              if [ "$i" -eq 60 ]; then
+                echo "  timed out waiting for $obj"
+                kubectl get application/provenance-collector -n argocd \
+                  -o custom-columns='SYNC:.status.sync.status,HEALTH:.status.health.status'
+                kubectl get all
+                exit 1
+              fi
+              sleep 5
+            done
+          done
+
       - name: Wait for dashboard
         run: |
-          kubectl wait --for=condition=available deployment/provenance-test-provenance-collector-web --timeout=120s
+          kubectl wait --for=condition=available \
+            deployment/provenance-test-provenance-collector-web --timeout=180s
 
       - name: Run provenance collection
         run: |

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -37,9 +37,15 @@ jobs:
 
       - name: Set up Nebari sandbox
         id: sandbox
-        uses: nebari-dev/action-nebari-sandbox@830ce3792bf96f5f3225acbc9a9f6f39570b7e58 # v2.2.0
+        uses: nebari-dev/action-nebari-sandbox@9ac369ebf87ac2ae217504dcbf824c77f70e429a # v3.0.0
         with:
-          profile: platform
+          # Pinned rather than tracking `latest`, so a NIC release cannot turn
+          # this job red without a deliberate bump — which is exactly how v2
+          # broke: `latest` rolled to NIC v0.13.0, which dropped the
+          # existing-cluster + `file://` GitOps combination v2 was built on.
+          # v3 requires NIC >= v0.13.0 (local/kind cluster + local repository
+          # providers). `profile` is gone in v3 — the action is platform-only.
+          nic-version: v0.13.0
           cluster-name: provenance-test
           resource-summary: "true"
 
@@ -49,14 +55,18 @@ jobs:
       - name: Build and load image
         run: |
           docker build --build-arg VERSION=test -t provenance-collector:test .
-          k3d image import provenance-collector:test --cluster provenance-test
+          # v3 provisions the cluster through NIC's `local` provider, which is
+          # kind, not k3d. `kind` is preinstalled on ubuntu-latest; the cluster
+          # name is the action's output (kubectl context is `kind-<name>`).
+          kind load docker-image provenance-collector:test \
+            --name ${{ steps.sandbox.outputs.cluster-name }}
 
       # add-software-pack waits for the Application CR to exist and to reach
       # status.health.status=Healthy by default (wait-for-application and
       # wait-healthy both default true). It also annotates nebari-root for a
       # refresh internally, so consumers don't need to poll or nudge themselves.
       - name: Register provenance-collector pack
-        uses: nebari-dev/action-nebari-sandbox/add-software-pack@830ce3792bf96f5f3225acbc9a9f6f39570b7e58 # v2.2.0
+        uses: nebari-dev/action-nebari-sandbox/add-software-pack@9ac369ebf87ac2ae217504dcbf824c77f70e429a # v3.0.0
         with:
           gitops-dir: ${{ steps.sandbox.outputs.gitops-dir }}
           app-name: provenance-collector
@@ -106,7 +116,7 @@ jobs:
       # another scan, and verify via the dashboard UI that picking each
       # timeline entry actually swaps the images table — not just the stat cards.
       #
-      # We can't use `busybox` as the sentinel — the sandbox's platform profile
+      # We can't use `busybox` as the sentinel — the sandbox's platform stack
       # ships `nebari-landing-webapi`, which uses `busybox:1.36` as a sidecar.
       # That collides with the test's image and the "appeared between scans"
       # check can't distinguish the two reports. `traefik/whoami` is small,
@@ -275,9 +285,10 @@ jobs:
           path: docs/screenshots/
           if-no-files-found: ignore
 
-      # Runs BEFORE Cleanup: the cluster must still exist for these kubectl
-      # calls to return anything. (Previously this ran after Cleanup, so every
-      # command hit a torn-down cluster and captured nothing.)
+      # The cluster must still exist for these kubectl calls to return
+      # anything. v3 destroys the deployment in the action's *post* step, which
+      # runs after every regular step in the job, so this is safe where it sits
+      # — there is no explicit cleanup step left to order against.
       - name: Debug info on failure
         if: failure()
         run: |
@@ -306,8 +317,3 @@ jobs:
           echo ""
           echo "=== Events ==="
           kubectl get events --sort-by=.lastTimestamp | tail -30
-
-      - name: Cleanup
-        if: always()
-        run: |
-          k3d cluster delete ${{ steps.sandbox.outputs.cluster-name || 'provenance-test' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is now pinned to `v0.13.0` rather than tracking `latest`.
 
 ### Fixed
+- Integration test no longer races ArgoCD's first sync. `add-software-pack`'s
+  `wait-healthy` returns as soon as the Application exists, because ArgoCD
+  aggregates an Application with zero live resources to `Healthy`; the
+  subsequent `kubectl wait` then exited `NotFound` immediately (it does not
+  retry on a missing object, so its `--timeout` never applied). The workflow
+  now waits for the chart's Deployment and CronJob to exist before waiting on
+  their conditions.
 - Integration test no longer fails at sandbox setup with `configuration
   validation failed: repository field is required`. The v2 action's default
   `nic-version: latest` rolled to NIC v0.13.0, which dropped the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Integration test migrated to `action-nebari-sandbox` v3, which provisions the
+  sandbox through NIC's `local` (kind) provider instead of k3d + NIC's
+  `existing` provider. The `profile` input is gone, the image is loaded with
+  `kind load docker-image`, and the explicit `k3d cluster delete` cleanup step
+  was dropped — v3 tears the deployment down in its own post step. `nic-version`
+  is now pinned to `v0.13.0` rather than tracking `latest`.
+
 ### Fixed
+- Integration test no longer fails at sandbox setup with `configuration
+  validation failed: repository field is required`. The v2 action's default
+  `nic-version: latest` rolled to NIC v0.13.0, which dropped the
+  existing-cluster + `file://` GitOps combination v2 depended on.
 - Dashboard branding: overriding `frontend.branding.theme.*.primary` now also
   rebrands button/badge hover and active states and the sidebar tokens.
   `--primary-hover`, `--sidebar-primary`, `--sidebar-primary-foreground` and


### PR DESCRIPTION
The integration test has been red since Aug 13 (every run, including plain
`main` pushes). Two independent problems; the first is what you see in the
logs, the second only became visible once the first was fixed.

## 1. The sandbox action's floating NIC dependency drifted

Every run died at **Set up Nebari sandbox** in ~50s:

```
{"level":"ERROR","msg":"Command execution failed",
 "error":"configuration validation failed: repository field is required"}
```

Nothing in this repo changed. `action-nebari-sandbox@v2.2.0` defaults to
`nic-version: latest`, which rolled forward to NIC **v0.13.0** — and that
release dropped the existing-cluster + local `file://` GitOps combination
v2 was built on. (Upstream shipped v2.3.0 pinning NIC to v0.12.0 as a
stopgap; v3.0.0 is the real migration, to NIC's `local`/kind provider.)

## 2. A latent ArgoCD race that v2's timings had been hiding

With the sandbox up, `Wait for dashboard` then failed in **0 seconds**:

```
12:26:11.10  Waiting up to 5m for application/provenance-collector to reach Healthy...
12:26:11.42    application/provenance-collector is Healthy      <- 0.3s later
12:26:11.53  Error from server (NotFound): deployments.apps "...-web" not found
12:26:12     <- the Deployment is actually created here
```

- ArgoCD aggregates an Application with **zero live resources** to
  `Healthy`, so `add-software-pack`'s `wait-healthy` was satisfied
  vacuously, 0.3s after the Application object appeared and before a
  single manifest had synced.
- `kubectl wait` **does not retry on a missing object** — it exits
  `NotFound` immediately, so `--timeout=120s` never applied.

Not a v3 regression; this would have bitten us eventually regardless.

## Changes

**v3 migration** (`b42fcf1`)
- Both the root action and `add-software-pack` → `@9ac369e # v3.0.0`
- Dropped `profile: platform` — the input no longer exists, v3 is platform-only
- Pinned `nic-version: v0.13.0` instead of tracking `latest`, so this exact
  class of breakage cannot recur without a deliberate bump
- `k3d image import` → `kind load docker-image` (kind 0.32.0 is preinstalled
  on `ubuntu-24.04`)
- Removed the `k3d cluster delete` cleanup step — v3 destroys the deployment
  in its own post step, including on failure and cancellation

**Race fix** (`19cc0d3`)
- Wait for the chart's Deployment and CronJob to *exist* before waiting on
  their conditions
- Availability wait 120s → 180s (kind provisions the reports PVC through
  local-path at a point in the sequence k3d did not)

`.github/argo-apps/provenance-collector.yaml` needs no change: v3's local
repository provider still resolves `file://${GITOPS_DIR}` under the
`nebari-apps` project, and `pullPolicy: Never` behaves the same against
kind's containerd.

## Verification

[Run 32727263762](https://github.com/nebari-dev/provenance-collector-pack/actions/runs/32727263762)
— `success` in 7m56s, all steps green, including all 10 Playwright tests
(export menu, scan-button auth, timeline switch).

## Two things a reviewer should know

- **The screenshot steps are unverified.** `Capture dashboard screenshots`
  and `Commit screenshots` are gated on `push` + `refs/heads/main`, so the
  `workflow_dispatch` runs above skipped them; they will first execute on
  merge. They drive the same Vite server the passing Playwright tests use,
  so the risk is low but not zero — and they commit back to the repo.
- **`actions/setup-go` is now dead weight.** Under v3 it is only needed to
  build NIC from source, and the Go binary compiles inside the Docker
  build. Left in to keep the diff focused; happy to drop it here or later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
