### PR TITLE
docs: link header logo to the packs portal and GitHub icon to this repo

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -17,9 +17,14 @@ export default defineConfig({
       description:
         'Compliance-grade supply-chain provenance for every container image and Helm release running on a Nebari cluster. A Kubernetes-native CronJob that discovers running images, resolves digests, verifies signatures, detects SLSA provenance and SBOM attestations, and emits a timestamped JSON report.',
       // Shared Nebari identity (brand colors, fonts, logo, favicon, footer, GitHub link)
-      // comes from the @nebari/starlight theme plugin. logoHref sets where the header logo
-      // takes the reader when they click it — nebari.dev for the project's main site.
-      plugins: [nebari({ logoHref: 'https://nebari.dev/' })],
+      // comes from the @nebari/starlight theme plugin. logoHref sends the header logo
+      // to the pack catalog; githubHref points the GitHub icon at this repository.
+      plugins: [
+        nebari({
+          logoHref: 'https://packs.nebari.dev/',
+          githubHref: 'https://github.com/nebari-dev/provenance-collector-pack',
+        }),
+      ],
       sidebar: [
         {
           label: 'Overview',

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/markdown-remark": "^7.2.2",
         "@astrojs/starlight": "^0.41.6",
-        "@nebari/starlight": "^0.2.1",
+        "@nebari/starlight": "^0.3.0",
         "astro": "^7.1.6",
         "rehype-mermaid": "^3.0.0",
         "sharp": "^0.35.3"
@@ -93,9 +93,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -111,9 +108,6 @@
       "integrity": "sha512-f0heT9ZZEseSu5bHCeb80eL2DH07ArE6U9xi1WT/PEusNjzPmEr3GJsjG1tRLo5VYUUYX7h3ScaqGmGrMOVGmw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -131,9 +125,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -149,9 +140,6 @@
       "integrity": "sha512-/Kebk8sO6HnLeSd691JkaAPfN7CqR9/KEXmWvyNPkaKNGmj8rTZ/lf2uXtnPu92Lan84UrKdIKVPy1fSo2encQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1218,9 +1206,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1236,9 +1221,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1256,9 +1238,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1274,9 +1253,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1294,9 +1270,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1312,9 +1285,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1332,9 +1302,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1351,9 +1318,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1369,9 +1333,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1395,9 +1356,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1419,9 +1377,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1445,9 +1400,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1469,9 +1421,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1495,9 +1444,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1520,9 +1466,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1544,9 +1487,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1727,9 +1667,10 @@
       }
     },
     "node_modules/@nebari/starlight": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@nebari/starlight/-/starlight-0.2.1.tgz",
-      "integrity": "sha512-XvpOJVlBwT1xhSpyqStNncBGuqowpWuqXpZwtv8xrOBCjz2VPNw2R4cchezb66lTHWqE5oohyTyOL3YrR+TBLw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@nebari/starlight/-/starlight-0.3.0.tgz",
+      "integrity": "sha512-c7GXiRJrr+pac5kOTxvDI20eGWapet03gMyCQQJLt0n1oTqylTWcMLcN/JzCH4saQtm+RYz2tcbcseDE9CVCqw==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@astrojs/starlight": ">=0.33.0 <1.0.0",
         "astro": ">=7.0.6"
@@ -4123,6 +4064,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.2",
     "@astrojs/starlight": "^0.41.6",
-    "@nebari/starlight": "^0.2.1",
+    "@nebari/starlight": "^0.3.0",
     "astro": "^7.1.6",
     "rehype-mermaid": "^3.0.0",
     "sharp": "^0.35.3"


### PR DESCRIPTION
## Summary

- `logoHref` now points at `https://packs.nebari.dev/` (the pack catalog) instead of `nebari.dev`, matching the rest of the pack fleet.
- Bump `@nebari/starlight` to `^0.3.0` and use its new `githubHref` option to point the header GitHub icon at this pack's repository instead of the nebari-dev org.

Part of a fleet-wide pass over all tracked packs (theme options added in nebari-dev/starlight#31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)